### PR TITLE
Feat/category

### DIFF
--- a/app/(tabs)/category.tsx
+++ b/app/(tabs)/category.tsx
@@ -1,5 +1,16 @@
+import { RoutineService } from "@/app/services/routine_service";
 import { Header } from "@/components/ui/_header";
-import { RoutineStorage } from "@/lib/storage";
+import {
+  DEFAULT_CATEGORIES,
+  EVENT_TYPES,
+  getCategoryBadgeStyle,
+  normalizeCategoryName,
+  normalizeHexColor,
+  uniqueColors,
+  uniqueCustomCategories,
+  type CustomCategory,
+} from "@/lib/category";
+import { getRoutineOccurrenceDates } from "@/lib/storage";
 import type { ScheduleRoutine } from "@/types/routine";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useFocusEffect } from "expo-router";
@@ -25,13 +36,10 @@ import ColorPicker, {
   Preview,
 } from "reanimated-color-picker";
 
+// 카테고리 탭 상태 타입: 진행중 / 완료됨
 type CategoryTab = "ACTIVE" | "COMPLETED";
 
-type CustomCategory = {
-  name: string;
-  color: string;
-};
-
+// 카테고리 숨김/수정 상태를 저장하는 메타 정보
 interface CategoryMeta {
   id: string;
   linkedCategoryId?: number | null;
@@ -42,6 +50,7 @@ interface CategoryMeta {
   updatedAt: string;
 }
 
+// 화면에 보여줄 카테고리 요약 데이터
 interface CategorySummary {
   key: string;
   metaId?: string;
@@ -63,26 +72,6 @@ const CUSTOM_COLOR_STORAGE_KEY = "@rutina/custom_colors";
 const CUSTOM_CATEGORY_STORAGE_KEY = "@rutina/custom_categories";
 const DEFAULT_COLOR = "#405886";
 
-// 기본으로 제공되는 고정 카테고리
-const DEFAULT_CATEGORIES = [
-  "기상",
-  "운동",
-  "공부",
-  "명상",
-  "저녁",
-  "기타",
-] as const;
-
-// 고정 카테고리별 배지/점 색상 설정
-const FIXED_EVENT_TYPES = {
-  기상: { bg: "#FAEEEE", dot: "#E79A95", text: "#5D4645" },
-  운동: { bg: "#FDF4EC", dot: "#EFB996", text: "#675141" },
-  공부: { bg: "#F1F1FB", dot: "#9FA2D6", text: "#3E426F" },
-  명상: { bg: "#F1F7EE", dot: "#A8CD9B", text: "#4C5D44" },
-  저녁: { bg: "#FEF9EE", dot: "#E6CF8A", text: "#685A3F" },
-  기타: { bg: "#F3F4F8", dot: "#C4C6D0", text: "#8A8C9A" },
-} as const;
-
 const DEFAULT_USER_COLOR_PALETTE = [
   "#405886",
   "#E79A95",
@@ -91,36 +80,6 @@ const DEFAULT_USER_COLOR_PALETTE = [
   "#A8CD9B",
   "#C4C6D0",
 ];
-// 색상값을 항상 #이 붙은 대문자 HEX 형식으로 맞춤
-const normalizeHexColor = (color: string) => {
-  const value = color.trim().toUpperCase();
-  return value.startsWith("#") ? value : `#${value}`;
-};
-
-const uniqueColors = (colors: string[]) => {
-  return Array.from(new Set(colors.map(normalizeHexColor)));
-};
-// 사용자 카테고리 중복 제거: 이름이 같으면 마지막 값으로 덮어씀
-const uniqueCustomCategories = (categories: CustomCategory[]) => {
-  const map = new Map<string, CustomCategory>();
-
-  categories.forEach((item) => {
-    const name = item.name.trim();
-    if (!name) return;
-
-    map.set(name.toLowerCase(), {
-      name,
-      color: normalizeHexColor(item.color),
-    });
-  });
-
-  return Array.from(map.values());
-};
-
-const normalizeCategoryName = (name?: string | null) => {
-  const trimmed = name?.trim();
-  return trimmed ? trimmed : "기타";
-};
 
 const toCategoryNameKey = (name: string) =>
   `name:${normalizeCategoryName(name).toLowerCase()}`;
@@ -128,28 +87,10 @@ const toCategoryNameKey = (name: string) =>
 const toCategoryIdKey = (id: number) => `id:${id}`;
 
 const isFixedCategoryName = (categoryName: string) => {
-  return Object.prototype.hasOwnProperty.call(FIXED_EVENT_TYPES, categoryName);
+  return Object.prototype.hasOwnProperty.call(EVENT_TYPES, categoryName);
 };
 
-const getCategoryBadgeStyle = (categoryName: string, categoryColor: string) => {
-  if (isFixedCategoryName(categoryName)) {
-    const fixedStyle =
-      FIXED_EVENT_TYPES[categoryName as keyof typeof FIXED_EVENT_TYPES];
-
-    return {
-      backgroundColor: fixedStyle.bg,
-      textColor: fixedStyle.text,
-      borderColor: fixedStyle.dot,
-    };
-  }
-
-  return {
-    backgroundColor: `${categoryColor}22`,
-    textColor: categoryColor,
-    borderColor: categoryColor,
-  };
-};
-// 루틴이 속한 카테고리를 id 우선으로 구분함
+// 루틴이 속한 카테고리를 id 우선으로 구분
 const getRoutineCategoryKey = (routine: ScheduleRoutine) => {
   if (typeof routine.categoryId === "number") {
     return toCategoryIdKey(routine.categoryId);
@@ -181,26 +122,44 @@ const isPastEndDate = (endDate?: string | null) => {
   // 종료일이 오늘보다 이전이면 기간이 지난 루틴으로 판단
   return endDate < getTodayString();
 };
+const isRoutineCompleted = (routine: ScheduleRoutine): boolean => {
+  // 조건 1: 종료일이 오늘보다 이전이면 완료
+  if (isPastEndDate(routine.endDate)) return true;
 
-const isRoutineCompleted = (routine: ScheduleRoutine) => {
+  // 조건 2: 수동 완료 처리
+  if (routine.state === false) return true;
+
+  const completedDates = routine.completedDates ?? [];
+  if (completedDates.length === 0) return false;
+
+  // 단순 1회 루틴
+  if (routine.startDate === routine.endDate) {
+    return completedDates.includes(routine.startDate);
+  }
+
+  // 기간 내 모든 반복 날짜를 완료했는지 검사
   const today = getTodayString();
+  const effectiveEnd =
+    routine.endDate && routine.endDate <= today ? routine.endDate : today;
 
-  // 오늘 일정 화면에서 체크한 루틴은 completedDates에 오늘 날짜가 들어왔다고 판단
-  const isCompletedToday =
-    Array.isArray(routine.completedDates) &&
-    routine.completedDates.includes(today);
+  const allDates = getRoutineOccurrenceDates(
+    routine,
+    routine.startDate,
+    effectiveEnd,
+  );
 
-  //state가 false인 경우 사용자가 직접 비활성화/완료 처리한 루틴으로 판단
-  const isManuallyCompleted = routine.state === false;
+  const normalizedCompletedDates = completedDates.map(
+    (date) => date.split("T")[0],
+  );
 
-  // 종료 기간이 지난 루틴도 완료된 루틴으로 판단
-  const isExpired = isPastEndDate(routine.endDate);
-
-  return isCompletedToday || isManuallyCompleted || isExpired;
+  return (
+    allDates.length > 0 &&
+    allDates.every((date) => normalizedCompletedDates.includes(date))
+  );
 };
 
 const loadRoutines = async () => {
-  return RoutineStorage.getAll();
+  return RoutineService.getAll();
 };
 // 숨김/수정된 카테고리 메타 정보를 불러옴
 const loadCategoryMetas = async (): Promise<CategoryMeta[]> => {
@@ -234,7 +193,7 @@ const loadCustomColors = async (): Promise<string[]> => {
     return [];
   }
 };
-// 사용자 카테고리를 불러오고, 예전 string[] 저장 형태도 함께 처리함
+// AsyncStorage에서 사용자 카테고리 불러오기
 const loadCustomCategories = async (): Promise<CustomCategory[]> => {
   try {
     const raw = await AsyncStorage.getItem(CUSTOM_CATEGORY_STORAGE_KEY);
@@ -289,7 +248,7 @@ const saveCustomCategories = async (categories: CustomCategory[]) => {
     throw error;
   }
 };
-// 루틴, 고정 카테고리, 사용자 카테고리, 메타 정보를 하나의 화면용 데이터로 합침
+// 루틴 + 기본 카테고리 + 사용자 카테고리를 화면용 데이터로 합치기
 const buildCategorySummaries = (
   routines: ScheduleRoutine[],
   metas: CategoryMeta[],
@@ -329,7 +288,7 @@ const buildCategorySummaries = (
   const presetCategories: CustomCategory[] = [
     ...DEFAULT_CATEGORIES.map((name) => ({
       name,
-      color: FIXED_EVENT_TYPES[name].dot,
+      color: EVENT_TYPES[name].dot,
     })),
     ...customCategories,
   ];
@@ -441,7 +400,7 @@ export default function CategoryScreen() {
   const [isMoveModalVisible, setIsMoveModalVisible] = useState(false);
   const categoryModalTranslateY = useRef(new Animated.Value(0)).current;
   const CATEGORY_MODAL_CLOSE_THRESHOLD = 120;
-  // 화면에 진입할 때 AsyncStorage와 루틴 저장소 데이터를 다시 불러옴
+  // 화면 진입 시 루틴, 카테고리 메타, 색상, 사용자 카테고리 다시 불러오기
   const refreshData = useCallback(async () => {
     try {
       setIsLoading(true);
@@ -476,34 +435,26 @@ export default function CategoryScreen() {
   const categories = useMemo(() => {
     return buildCategorySummaries(routines, categoryMetas, customCategories);
   }, [routines, categoryMetas, customCategories]);
-  // 숨김 처리되지 않은 카테고리 중 현재 탭에 맞는 루틴만 보여줌
+  // 현재 선택된 탭에 맞게 카테고리별 루틴 필터링
   const visibleCategories = useMemo(() => {
     return categories
-      .filter((category) => !category.isHidden)
+      .filter((category) => !category.isHidden) // 숨김 카테고리만 제외
       .map((category) => {
-        // 카테고리 자체를 이동시키지 않고, 탭에 맞는 루틴만 분리해서 보여줌
+        // 현재 탭에 맞는 루틴만 카드 안에 표시
         const filteredRoutines = category.routines.filter((routine) => {
           const completed = isRoutineCompleted(routine);
-
-          if (selectedTab === "ACTIVE") {
-            return !completed;
-          }
-
-          return completed;
+          return selectedTab === "ACTIVE" ? !completed : completed;
         });
 
         return {
           ...category,
           routines: filteredRoutines,
-          totalCount: filteredRoutines.length,
-          completedCount: filteredRoutines.filter(isRoutineCompleted).length,
-          // 완료 탭에서는 루틴 기준으로 완료 상태를 표시
+          totalCount: category.totalCount,
+          completedCount: category.completedCount,
           isCompletedCategory: selectedTab === "COMPLETED",
         };
-      })
-      .filter((category) => category.totalCount > 0);
+      });
   }, [categories, selectedTab]);
-
   const hiddenCategories = useMemo(() => {
     return categories.filter((category) => category.isHidden);
   }, [categories]);
@@ -528,7 +479,7 @@ export default function CategoryScreen() {
     setPickerColor(DEFAULT_COLOR);
     setShowColorPickerModal(false);
   };
-
+  // 카테고리 추가 모달 열기
   const openAddCategoryModal = () => {
     categoryModalTranslateY.setValue(0);
     setEditingCategory(null);
@@ -538,7 +489,7 @@ export default function CategoryScreen() {
     setShowColorPickerModal(false);
     setIsCategoryModalVisible(true);
   };
-
+  // 카테고리 수정 모달 열기
   const openEditCategoryModal = (category: CategorySummary) => {
     categoryModalTranslateY.setValue(0);
     setEditingCategory(category);
@@ -579,7 +530,7 @@ export default function CategoryScreen() {
       friction: 12,
     }).start();
   };
-  // 모달을 아래로 스와이프하면 닫히도록 처리
+  // 바텀시트 모달을 아래로 스와이프해서 닫기
   const categoryModalPanResponder = useRef(
     PanResponder.create({
       onMoveShouldSetPanResponder: (_, gestureState) => {
@@ -623,8 +574,7 @@ export default function CategoryScreen() {
   };
 
   const handleSelectFixedCategory = (categoryName: string) => {
-    const fixedStyle =
-      FIXED_EVENT_TYPES[categoryName as keyof typeof FIXED_EVENT_TYPES];
+    const fixedStyle = EVENT_TYPES[categoryName as keyof typeof EVENT_TYPES];
 
     setCategoryNameInput(categoryName);
     setSelectedColor(fixedStyle.dot);
@@ -757,7 +707,7 @@ export default function CategoryScreen() {
     if (categoryToDelete.totalCount > 0) {
       Alert.alert(
         "카테고리 삭제",
-        `"${categoryToDelete.name}"에 연결된 일정이 있어요. 다른 카테고리로 이동한 뒤 삭제할까요?`,
+        `"${categoryToDelete.name}"에 연결된 루틴이 있어요. 다른 카테고리로 이동한 뒤 삭제할까요?`,
         [
           { text: "취소", style: "cancel" },
           {
@@ -934,7 +884,7 @@ export default function CategoryScreen() {
       ];
     });
   };
-
+  // 숨긴 카테고리 다시 복구
   const handleRestoreCategory = async (category: CategorySummary) => {
     await upsertCategoryMeta((prev) =>
       prev.map((meta) => {
@@ -970,11 +920,21 @@ export default function CategoryScreen() {
       };
     });
 
-    await RoutineStorage.saveAll(updatedRoutines);
+    await RoutineService.updateAll(updatedRoutines);
     setRoutines(updatedRoutines);
   };
-  // 카테고리 삭제: 연결된 루틴이 있으면 먼저 이동 모달을 띄움
+  // 카테고리 삭제 처리
   const handleDeleteCategory = async (category: CategorySummary) => {
+    //기본 카테고리는 삭제 불가
+    if (category.isFixedCategory) {
+      Alert.alert(
+        "삭제 불가",
+        `"${category.name}"은 기본 카테고리라 삭제할 수 없어요.`,
+        [{ text: "확인" }],
+      );
+      return;
+    }
+
     if (category.totalCount > 0) {
       setMoveSourceCategory(category);
       setMoveTargetKey(null);
@@ -988,16 +948,13 @@ export default function CategoryScreen() {
         text: "삭제",
         style: "destructive",
         onPress: async () => {
-          if (!category.isFixedCategory) {
-            const filteredCustomCategories = customCategories.filter(
-              (item) =>
-                item.name.trim().toLowerCase() !==
-                category.name.trim().toLowerCase(),
-            );
-
-            await saveCustomCategories(filteredCustomCategories);
-            setCustomCategories(filteredCustomCategories);
-          }
+          const filteredCustomCategories = customCategories.filter(
+            (item) =>
+              item.name.trim().toLowerCase() !==
+              category.name.trim().toLowerCase(),
+          );
+          await saveCustomCategories(filteredCustomCategories);
+          setCustomCategories(filteredCustomCategories);
 
           await upsertCategoryMeta((prev) =>
             prev.filter((meta) => {
@@ -1109,7 +1066,9 @@ export default function CategoryScreen() {
             item.routines.slice(0, 3).map(renderRoutineItem)
           ) : (
             <Text style={styles.emptyRoutineText}>
-              연결된 일정이 아직 없어요.
+              {selectedTab === "ACTIVE"
+                ? "연결된 루틴이 아직 없어요."
+                : "완료된 루틴이 아직 없어요."}
             </Text>
           )}
         </View>
@@ -1324,7 +1283,7 @@ export default function CategoryScreen() {
                     <Text style={styles.inputLabel}>고정 카테고리</Text>
                     <View style={styles.categoryGrid}>
                       {DEFAULT_CATEGORIES.map((categoryName) => {
-                        const fixedStyle = FIXED_EVENT_TYPES[categoryName];
+                        const fixedStyle = EVENT_TYPES[categoryName];
                         const badgeStyle = getCategoryBadgeStyle(
                           categoryName,
                           fixedStyle.dot,
@@ -1555,7 +1514,7 @@ export default function CategoryScreen() {
               <Text style={styles.modalTitle}>카테고리 이동 후 삭제</Text>
 
               <Text style={styles.moveDescription}>
-                "{moveSourceCategory?.name}"에 연결된 일정이 있어서 바로 삭제할
+                "{moveSourceCategory?.name}"에 연결된 루틴이 있어서 바로 삭제할
                 수 없어요. 다른 카테고리로 옮긴 뒤 삭제할게요.
               </Text>
 

--- a/app/(tabs)/data.tsx
+++ b/app/(tabs)/data.tsx
@@ -1,9 +1,11 @@
+import { RoutineService } from "@/app/services/routine_service";
 import { ScheduleDetailModal } from "@/components/schedule_detail_modal";
 import { Header } from "@/components/ui/_header";
-import { RoutineStorage } from "@/lib/storage";
+import { getCategoryStyle, normalizeCategoryName } from "@/lib/category";
 import type { ScheduleRoutine } from "@/types/routine";
 import { useFocusEffect } from "@react-navigation/native";
 import React, { useCallback, useMemo, useState } from "react";
+
 import {
   Pressable,
   SafeAreaView,
@@ -13,18 +15,22 @@ import {
   View,
 } from "react-native";
 
+// 통계 화면 보기 모드 타입
 type ViewMode = "YEAR" | "MONTH" | "WEEK";
 
+// 카테고리별로 묶은 루틴 타입
 type GroupedRoutine = {
   categoryName: string;
   routines: ScheduleRoutine[];
 };
 
+// 년/주 단위 히트맵 셀 타입
 type HeatmapCell = {
   key: string;
   filled: boolean;
 };
 
+// 월 달력 셀 타입
 type CalendarCell = {
   key: string;
   filled: boolean;
@@ -32,23 +38,7 @@ type CalendarCell = {
   isEmpty?: boolean;
 };
 
-type EventTypeStyle = {
-  bg: string;
-  dot: string;
-  text: string;
-};
-
-const DEFAULT_CATEGORY_NAME = "기타";
 const MAIN_COLOR = "#405886";
-
-const eventTypes: Record<string, EventTypeStyle> = {
-  기상: { bg: "#FAEEEE", dot: "#E79A95", text: "#5D4645" },
-  운동: { bg: "#FDF4EC", dot: "#EFB996", text: "#675141" },
-  공부: { bg: "#F1F1FB", dot: "#9FA2D6", text: "#3E426F" },
-  명상: { bg: "#F1F7EE", dot: "#A8CD9B", text: "#4C5D44" },
-  저녁: { bg: "#FEF9EE", dot: "#E6CF8A", text: "#685A3F" },
-  기타: { bg: "#F3F4F8", dot: "#C4C6D0", text: "#8A8C9A" },
-};
 
 const MONTH_LABELS = [
   "1월",
@@ -67,44 +57,7 @@ const MONTH_LABELS = [
 
 const WEEK_LABELS = ["일", "월", "화", "수", "목", "금", "토"];
 
-function hexToRgba(hex: string, alpha: number) {
-  const cleaned = hex.replace("#", "");
-
-  if (cleaned.length !== 6) {
-    return hex;
-  }
-
-  const r = parseInt(cleaned.slice(0, 2), 16);
-  const g = parseInt(cleaned.slice(2, 4), 16);
-  const b = parseInt(cleaned.slice(4, 6), 16);
-
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
-
-function normalizeCategoryName(categoryName?: string | null) {
-  const trimmed = categoryName?.trim();
-  return trimmed ? trimmed : DEFAULT_CATEGORY_NAME;
-}
-
-function getCategoryStyle(item: ScheduleRoutine): EventTypeStyle {
-  const typeLabel = item.categoryName ?? DEFAULT_CATEGORY_NAME;
-  const fixedStyle = eventTypes[typeLabel];
-
-  if (fixedStyle) {
-    return fixedStyle;
-  }
-  // 커스텀 카테고리 색상 적용
-  if (item.color) {
-    return {
-      bg: hexToRgba(item.color, 0.14),
-      dot: item.color,
-      text: item.color,
-    };
-  }
-
-  return eventTypes[DEFAULT_CATEGORY_NAME];
-}
-
+// 선택한 날짜가 포함된 주의 시작일 계산
 function getWeekStart(date: Date) {
   const start = new Date(date);
   start.setHours(0, 0, 0, 0);
@@ -112,6 +65,7 @@ function getWeekStart(date: Date) {
   return start;
 }
 
+// 선택한 날짜가 포함된 주의 종료일 계산
 function getWeekEnd(date: Date) {
   const end = new Date(getWeekStart(date));
   end.setDate(end.getDate() + 6);
@@ -119,6 +73,7 @@ function getWeekEnd(date: Date) {
   return end;
 }
 
+// 문자열 날짜를 Date 객체로 변환
 function parseDateValue(value: unknown) {
   if (typeof value !== "string" || !value.trim()) {
     return null;
@@ -137,19 +92,24 @@ function parseDateValue(value: unknown) {
   return date;
 }
 
+// Date 객체를 YYYY-MM-DD 형식으로 변환
 function formatDateKey(date: Date) {
   const year = date.getFullYear();
   const month = String(date.getMonth() + 1).padStart(2, "0");
   const day = String(date.getDate()).padStart(2, "0");
   return `${year}-${month}-${day}`;
 }
+// 루틴 시작일 가져오기
 function getRoutineStartDate(routine: ScheduleRoutine) {
   return parseDateValue(routine.startDate) || null;
 }
 
+// 루틴 종료일 가져오기
 function getRoutineEndDate(routine: ScheduleRoutine) {
   return parseDateValue(routine.endDate) || getRoutineStartDate(routine);
 }
+
+// 특정 날짜가 루틴 기간 안에 포함되는지 확인
 function isDateInRoutineRange(routine: ScheduleRoutine, targetDate: Date) {
   const startDate = getRoutineStartDate(routine);
   const endDate = getRoutineEndDate(routine);
@@ -160,15 +120,16 @@ function isDateInRoutineRange(routine: ScheduleRoutine, targetDate: Date) {
 
   const normalizedTarget = new Date(targetDate);
   normalizedTarget.setHours(0, 0, 0, 0);
-  // 시작일~종료일 범위 안에 있는 날짜인지 확인
   return normalizedTarget >= startDate && normalizedTarget <= endDate;
 }
+// 특정 날짜에 루틴이 완료되었는지 확인
 function isRoutineCompletedOnDate(routine: ScheduleRoutine, targetDate: Date) {
   const targetDateKey = formatDateKey(targetDate);
   const completedDates = routine.completedDates ?? [];
-  // 해당 날짜가 완료 기록에 포함되어 있는지 확인
   return completedDates.includes(targetDateKey);
 }
+
+// 루틴 기간과 현재 선택한 기간이 겹치는지 확인
 function doesRoutineOverlapPeriod(
   routine: ScheduleRoutine,
   periodStart: Date,
@@ -186,16 +147,16 @@ function doesRoutineOverlapPeriod(
 
   const normalizedEnd = new Date(periodEnd);
   normalizedEnd.setHours(23, 59, 59, 999);
-  // 루틴 기간과 현재 보는 기간이 겹치는지 확인
   return startDate <= normalizedEnd && endDate >= normalizedStart;
 }
-
+// 선택한 연도에 해당하는 루틴인지 확인
 function isRoutineInSameYear(routine: ScheduleRoutine, year: number) {
   const yearStart = new Date(year, 0, 1);
   const yearEnd = new Date(year, 11, 31);
   return doesRoutineOverlapPeriod(routine, yearStart, yearEnd);
 }
 
+// 선택한 월에 해당하는 루틴인지 확인
 function isRoutineInSameMonth(
   routine: ScheduleRoutine,
   year: number,
@@ -205,13 +166,13 @@ function isRoutineInSameMonth(
   const monthEnd = new Date(year, month + 1, 0);
   return doesRoutineOverlapPeriod(routine, monthStart, monthEnd);
 }
-
+// 선택한 주에 해당하는 루틴인지 확인
 function isRoutineInSameWeek(routine: ScheduleRoutine, selectedDate: Date) {
   const weekStart = getWeekStart(selectedDate);
   const weekEnd = getWeekEnd(selectedDate);
   return doesRoutineOverlapPeriod(routine, weekStart, weekEnd);
 }
-
+// 연간 통계 히트맵 셀 생성
 function buildYearCells(routine: ScheduleRoutine, year: number): HeatmapCell[] {
   const startDate = new Date(year, 0, 1);
   const endDate = new Date(year, 11, 31);
@@ -235,7 +196,7 @@ function buildYearCells(routine: ScheduleRoutine, year: number): HeatmapCell[] {
 
   return cells;
 }
-
+// 주간 통계 히트맵 셀 생성
 function buildWeekCells(
   routine: ScheduleRoutine,
   selectedWeekDate: Date,
@@ -254,7 +215,7 @@ function buildWeekCells(
     };
   });
 }
-
+// 월간 달력 셀 생성
 function buildMonthCalendarCells(
   routine: ScheduleRoutine,
   year: number,
@@ -265,7 +226,7 @@ function buildMonthCalendarCells(
   const startWeekday = firstDay.getDay();
 
   const cells: CalendarCell[] = [];
-
+  // 월 시작 전 빈 칸 채우기
   for (let i = 0; i < startWeekday; i++) {
     cells.push({
       key: `${routine.id}-month-empty-start-${i}`,
@@ -274,7 +235,7 @@ function buildMonthCalendarCells(
       isEmpty: true,
     });
   }
-
+  // 실제 날짜 셀 생성
   for (let day = 1; day <= daysInMonth; day++) {
     const currentDate = new Date(year, month, day);
 
@@ -286,7 +247,7 @@ function buildMonthCalendarCells(
       label: String(day),
     });
   }
-
+  // 마지막 줄을 7칸으로 맞추기 위한 빈 칸 추가
   while (cells.length % 7 !== 0) {
     cells.push({
       key: `${routine.id}-month-empty-end-${cells.length}`,
@@ -298,7 +259,7 @@ function buildMonthCalendarCells(
 
   return cells;
 }
-
+// 루틴을 카테고리별로 묶기
 function groupByCategory(routines: ScheduleRoutine[]): GroupedRoutine[] {
   const groupedMap = new Map<string, ScheduleRoutine[]>();
 
@@ -324,7 +285,7 @@ function formatYear(year: number) {
 function formatMonth(year: number, month: number) {
   return `${year}년 ${month + 1}월`;
 }
-
+// 주간 표시 텍스트 생성
 function formatWeek(selectedDate: Date) {
   const start = getWeekStart(selectedDate);
   const end = getWeekEnd(selectedDate);
@@ -336,7 +297,7 @@ function formatWeek(selectedDate: Date) {
 
   return `${startMonth}/${startDay} - ${endMonth}/${endDay}`;
 }
-
+// 루틴 하나의 통계 카드
 function HeatmapRow({
   routine,
   viewMode,
@@ -353,17 +314,19 @@ function HeatmapRow({
   onPress: (routine: ScheduleRoutine) => void;
 }) {
   const categoryStyle = getCategoryStyle(routine);
-
+  // 연간 보기일 때만 연간 셀 계산
   const yearCells = useMemo(() => {
     if (viewMode !== "YEAR") return [];
     return buildYearCells(routine, selectedYear);
   }, [routine, viewMode, selectedYear]);
 
+  // 월간 보기일 때만 월간 셀 계산
   const monthCells = useMemo(() => {
     if (viewMode !== "MONTH") return [];
     return buildMonthCalendarCells(routine, selectedYear, selectedMonth);
   }, [routine, viewMode, selectedYear, selectedMonth]);
 
+  // 주간 보기일 때만 주간 셀 계산
   const weekCells = useMemo(() => {
     if (viewMode !== "WEEK") return [];
     return buildWeekCells(routine, selectedWeekDate);
@@ -383,6 +346,7 @@ function HeatmapRow({
         </Text>
       </View>
 
+      {/* 연간 통계 화면 */}
       {viewMode === "YEAR" && (
         <>
           <View style={styles.yearHeatmapWrap}>
@@ -410,6 +374,7 @@ function HeatmapRow({
         </>
       )}
 
+      {/* 월간 통계 화면 */}
       {viewMode === "MONTH" && (
         <>
           <View style={styles.monthWeekLabelRow}>
@@ -450,6 +415,7 @@ function HeatmapRow({
         </>
       )}
 
+      {/* 주간 통계 화면 */}
       {viewMode === "WEEK" && (
         <>
           <View style={styles.weekContainer}>
@@ -483,21 +449,27 @@ function HeatmapRow({
 
 export default function DataScreen() {
   const today = new Date();
-
+  // 저장된 루틴 목록
   const [routines, setRoutines] = useState<ScheduleRoutine[]>([]);
+  // 현재 통계 보기 모드
   const [viewMode, setViewMode] = useState<ViewMode>("YEAR");
+  // 선택된 연도/월/주
   const [selectedYear, setSelectedYear] = useState(today.getFullYear());
   const [selectedMonth, setSelectedMonth] = useState(today.getMonth());
   const [selectedWeekDate, setSelectedWeekDate] = useState(today);
+  // 카테고리 접기/펼치기 상태
   const [expandedCategories, setExpandedCategories] = useState<
     Record<string, boolean>
   >({});
+  // 상세 모달에 보여줄 루틴
   const [selectedRoutine, setSelectedRoutine] =
     useState<ScheduleRoutine | null>(null);
+  // 상세 모달 표시 여부
   const [showDetailModal, setShowDetailModal] = useState(false);
+  // 저장소에서 루틴 데이터 불러오기
   const loadRoutines = useCallback(async () => {
     try {
-      const stored = await RoutineStorage.getAll();
+      const stored = await RoutineService.getAll();
       setRoutines(stored);
     } catch (error) {
       console.error("통계 데이터 불러오기 실패", error);
@@ -510,7 +482,7 @@ export default function DataScreen() {
       loadRoutines();
     }, [loadRoutines]),
   );
-
+  // 현재 보기 모드에 맞는 루틴만 필터링
   const filteredRoutines = useMemo(() => {
     if (viewMode === "YEAR") {
       return routines.filter((routine) =>
@@ -528,11 +500,11 @@ export default function DataScreen() {
       isRoutineInSameWeek(routine, selectedWeekDate),
     );
   }, [routines, viewMode, selectedYear, selectedMonth, selectedWeekDate]);
-
+  // 필터링된 루틴을 카테고리별로 묶기
   const groupedRoutines = useMemo(() => {
     return groupByCategory(filteredRoutines);
   }, [filteredRoutines]);
-
+  // 새로 생긴 카테고리는 기본적으로 펼쳐진 상태로 설정
   React.useEffect(() => {
     setExpandedCategories((prev) => {
       const nextState = { ...prev };
@@ -546,24 +518,24 @@ export default function DataScreen() {
       return nextState;
     });
   }, [groupedRoutines]);
-
+  // 카테고리 접기/펼치기
   const toggleCategory = (categoryName: string) => {
     setExpandedCategories((prev) => ({
       ...prev,
       [categoryName]: !prev[categoryName],
     }));
   };
-
+  // 연도 이동
   const moveYear = (diff: number) => {
     setSelectedYear((prev) => prev + diff);
   };
-
+  // 월 이동
   const moveMonth = (diff: number) => {
     const nextDate = new Date(selectedYear, selectedMonth + diff, 1);
     setSelectedYear(nextDate.getFullYear());
     setSelectedMonth(nextDate.getMonth());
   };
-
+  // 주 이동
   const moveWeek = (diff: number) => {
     setSelectedWeekDate((prev) => {
       const nextDate = new Date(prev);
@@ -571,6 +543,7 @@ export default function DataScreen() {
       return nextDate;
     });
   };
+  // 루틴 클릭 시 상세 모달 열기
   const handlePressRoutine = (routine: ScheduleRoutine) => {
     setSelectedRoutine(routine);
     setShowDetailModal(true);
@@ -592,7 +565,7 @@ export default function DataScreen() {
                 루틴별 완료 기록을 확인해보세요
               </Text>
             </View>
-
+            {/* 통계 보기 모드 선택 */}
             <View style={styles.viewTabRow}>
               <Pressable
                 style={[
@@ -645,7 +618,7 @@ export default function DataScreen() {
                 </Text>
               </Pressable>
             </View>
-
+            {/* 현재 선택된 기간 이동 영역 */}
             <View style={styles.periodRow}>
               <Pressable
                 style={styles.periodMoveButton}
@@ -693,7 +666,7 @@ export default function DataScreen() {
                 <Text style={styles.periodMoveText}>›</Text>
               </Pressable>
             </View>
-
+            {/* 표시할 루틴이 없을 때 */}
             {groupedRoutines.length === 0 ? (
               <View style={styles.emptyBox}>
                 <Text style={styles.emptyText}>표시할 루틴이 없어요.</Text>
@@ -721,7 +694,7 @@ export default function DataScreen() {
                         {isExpanded ? "접기" : "펼치기"}
                       </Text>
                     </Pressable>
-
+                    {/* 카테고리가 펼쳐져 있을 때 루틴 목록 표시 */}
                     {isExpanded && (
                       <View style={styles.categoryBody}>
                         {group.routines.map((routine) => (
@@ -744,6 +717,7 @@ export default function DataScreen() {
           </View>
         </ScrollView>
       </View>
+      {/* 루틴 상세 모달 */}
       <ScheduleDetailModal
         visible={showDetailModal}
         routine={selectedRoutine}
@@ -754,6 +728,7 @@ export default function DataScreen() {
         onUpdated={async () => {
           await loadRoutines();
         }}
+        readOnly
       />
     </SafeAreaView>
   );

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,19 +1,12 @@
+import { RoutineService } from "@/app/services/routine_service";
 import ScheduleContent from "@/components/schedule_content";
 import { Header } from "@/components/ui/_header";
 import AppCalendar from "@/components/ui/app_calendar";
-import { RoutineStorage } from "@/lib/storage";
+import { EVENT_TYPES } from "@/lib/category";
+import { shouldShowRoutineOnDate } from "@/lib/storage";
 import type { MarkedDates } from "@/types/calendar";
 import type { ScheduleRoutine } from "@/types/routine";
-import {
-  addDays,
-  differenceInCalendarDays,
-  differenceInCalendarMonths,
-  differenceInCalendarWeeks,
-  differenceInCalendarYears,
-  format,
-  isSameDay,
-  startOfWeek,
-} from "date-fns";
+import { addDays, format, isSameDay, startOfWeek } from "date-fns";
 import { ko } from "date-fns/locale";
 import { useFocusEffect } from "expo-router";
 import React, {
@@ -36,16 +29,8 @@ import {
   View,
 } from "react-native";
 
-const eventTypes = {
-  기상: { bg: "#FAEEEE", dot: "#E79A95", text: "#5D4645" },
-  운동: { bg: "#FDF4EC", dot: "#EFB996", text: "#675141" },
-  공부: { bg: "#F1F1FB", dot: "#9FA2D6", text: "#3E426F" },
-  명상: { bg: "#F1F7EE", dot: "#A8CD9B", text: "#4C5D44" },
-  저녁: { bg: "#FEF9EE", dot: "#E6CF8A", text: "#685A3F" },
-};
-
 const SCREEN_WIDTH = Dimensions.get("window").width;
-
+// 시간표에 표시할 일정 타입
 type TimetableEvent = {
   id: string;
   title: string;
@@ -54,13 +39,13 @@ type TimetableEvent = {
   type: string;
   color?: string;
 };
-
+// HEX 색상에 투명도 값 추가
 function addAlphaToHex(hexColor: string, alpha = "22") {
   if (!hexColor.startsWith("#")) return "#F1F1FB";
   if (hexColor.length === 7) return `${hexColor}${alpha}`;
   return hexColor;
 }
-
+// 시간을 분 단위로 변환
 function parseTimeToMinutes(time?: string | null) {
   // "09:30", "09:30:00" 둘 다 대응
   if (!time) return null;
@@ -76,80 +61,7 @@ function parseTimeToMinutes(time?: string | null) {
   return hour * 60 + minute;
 }
 
-function isDateInRange(targetDate: string, startDate: string, endDate: string) {
-  // yyyy-MM-dd 형식 문자열 비교로 날짜 범위 확인
-  return targetDate >= startDate && targetDate <= endDate;
-}
-
-//선택한 날짜를 요일 값으로 변환
-function getWeekdayValue(date: Date) {
-  const weekdays = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"] as const;
-  return weekdays[date.getDay()];
-}
-
-//나중에 API에서 repeatDays가 문자열로 와도 처리 가능하게 정리
-function normalizeRepeatDays(
-  repeatDays?: ScheduleRoutine["repeatDays"] | string | null,
-) {
-  if (!repeatDays) return [];
-
-  if (Array.isArray(repeatDays)) {
-    return repeatDays;
-  }
-
-  return repeatDays
-    .split(",")
-    .map((day) => day.trim())
-    .filter(Boolean);
-}
-
-function isRoutineVisibleOnDate(
-  routine: ScheduleRoutine,
-  targetDateString: string,
-) {
-  if (!isDateInRange(targetDateString, routine.startDate, routine.endDate)) {
-    return false;
-  }
-
-  if (!routine.repeatType || routine.repeatType === "NONE") {
-    return true;
-  }
-
-  if (routine.repeatType === "DAILY") {
-    return true;
-  }
-
-  if (routine.repeatType === "CUSTOM") {
-    const every = routine.repeatInterval ?? 1;
-
-    const startDate = new Date(routine.startDate);
-    const targetDate = new Date(targetDateString);
-
-    if (routine.repeatUnit === "DAY") {
-      return differenceInCalendarDays(targetDate, startDate) % every === 0;
-    }
-
-    if (routine.repeatUnit === "WEEK") {
-      const weekMatched =
-        differenceInCalendarWeeks(targetDate, startDate) % every === 0;
-
-      const selectedWeekday = getWeekdayValue(targetDate);
-      const repeatDays = normalizeRepeatDays(routine.repeatDays);
-
-      return weekMatched && repeatDays.includes(selectedWeekday);
-    }
-
-    if (routine.repeatUnit === "MONTH") {
-      return differenceInCalendarMonths(targetDate, startDate) % every === 0;
-    }
-
-    if (routine.repeatUnit === "YEAR") {
-      return differenceInCalendarYears(targetDate, startDate) % every === 0;
-    }
-  }
-
-  return true;
-}
+// 저장된 루틴을 시간표에서 사용할 데이터로 변환
 function buildTimetableEvents(
   routines: ScheduleRoutine[],
   targetDateString: string,
@@ -158,7 +70,7 @@ function buildTimetableEvents(
 
   routines.forEach((routine) => {
     // 현재 선택 날짜에 보여야 하는 일정만 통과
-    if (!isRoutineVisibleOnDate(routine, targetDateString)) {
+    if (!shouldShowRoutineOnDate(routine, targetDateString)) {
       return;
     }
 
@@ -188,12 +100,12 @@ function buildTimetableEvents(
       color: routine.color,
     });
   });
-
+  // 시작 시간이 빠른 순서대로 정렬
   return events.sort((a, b) => a.startMinute - b.startMinute);
 }
-
+// 카테고리명에 맞는 색상 스타일 반환
 function getEventStyle(type: string, color?: string) {
-  const fixedStyle = eventTypes[type as keyof typeof eventTypes];
+  const fixedStyle = EVENT_TYPES[type as keyof typeof EVENT_TYPES];
 
   if (fixedStyle) {
     return fixedStyle;
@@ -209,10 +121,15 @@ function getEventStyle(type: string, color?: string) {
 }
 
 export default function HomeScreen() {
+  // 현재 선택된 날짜
   const [currentDate, setCurrentDate] = useState(new Date());
+  // 월간 캘린더 표시 여부
   const [isCalendarVisible, setIsCalendarVisible] = useState(false);
+  // 가로 스와이프 페이지 상태: left는 타임테이블, right는 일정 화면
   const [activePage, setActivePage] = useState<"left" | "right">("left");
+  // 현재 시간 표시용 상태
   const [currentTime, setCurrentTime] = useState(new Date());
+  // 저장소에서 불러온 전체 루틴
   const [storedRoutines, setStoredRoutines] = useState<ScheduleRoutine[]>([]);
 
   const startHour = 0;
@@ -224,16 +141,16 @@ export default function HomeScreen() {
     (_, i) => startHour + i,
   );
   const columns = [0, 1, 2, 3, 4, 5];
-
+  // 시간표 스크롤 위치 제어용 ref
   const timetableScrollRef = useRef<ScrollView>(null);
 
   const currentDateString = format(currentDate, "yyyy-MM-dd");
-
+  // 현재 선택된 날짜가 포함된 주 계산
   const startOfCurrentWeek = startOfWeek(currentDate, { weekStartsOn: 0 });
   const weekDays = Array.from({ length: 7 }).map((_, i) =>
     addDays(startOfCurrentWeek, i),
   );
-
+  // 위/아래 스와이프로 캘린더 열고 닫기
   const panResponder = useRef(
     PanResponder.create({
       onMoveShouldSetPanResponder: (_, gestureState) => {
@@ -248,28 +165,24 @@ export default function HomeScreen() {
       },
     }),
   ).current;
-
+  // AsyncStorage에 저장된 루틴 불러오기
   const loadStoredRoutines = useCallback(async () => {
     try {
       // storage.ts에 저장된 전체 일정 불러오기
-      const routines = await RoutineStorage.getAll();
+      const routines = await RoutineService.getAll();
       setStoredRoutines(routines);
     } catch (error) {
-      console.error("저장된 일정 불러오기 실패", error);
+      console.error("저장된 루틴 불러오기 실패", error);
       setStoredRoutines([]);
     }
   }, []);
-
-  useEffect(() => {
-    loadStoredRoutines();
-  }, [loadStoredRoutines]);
-
+  // 다른 화면 갔다가 돌아올 때 최신 루틴 다시 불러오기
   useFocusEffect(
     useCallback(() => {
       loadStoredRoutines();
     }, [loadStoredRoutines]),
   );
-
+  // 현재 시간 기준으로 시간표 위치 이동 + 1분마다 현재 시간 갱신
   useEffect(() => {
     const currentHour = currentTime.getHours();
     const yOffset = Math.max(0, (currentHour - startHour - 1) * hourHeight);
@@ -288,6 +201,7 @@ export default function HomeScreen() {
     };
   }, [currentTime, startHour, hourHeight]);
 
+  // 가로 스와이프가 끝났을 때 현재 페이지 상태 변경
   const handleHorizontalScrollEnd = (
     event: NativeSyntheticEvent<NativeScrollEvent>,
   ) => {
@@ -297,12 +211,12 @@ export default function HomeScreen() {
 
     setActivePage(currentPage === 0 ? "left" : "right");
   };
-
+  // 현재 선택 날짜에 시간표로 보여줄 일정 목록
   const timetableEvents = useMemo(() => {
     // 현재 선택 날짜 기준으로 시간표에 보여줄 일정만 생성
     return buildTimetableEvents(storedRoutines, currentDateString);
   }, [storedRoutines, currentDateString]);
-
+  // 캘린더에 선택 날짜 표시
   const calendarMarkedDates = useMemo(() => {
     const marked: MarkedDates = {
       [currentDateString]: {
@@ -314,7 +228,7 @@ export default function HomeScreen() {
     weekDays.forEach((date) => {
       const dateString = format(date, "yyyy-MM-dd");
       const hasRoutine = storedRoutines.some((routine) =>
-        isRoutineVisibleOnDate(routine, dateString),
+        shouldShowRoutineOnDate(routine, dateString),
       );
 
       if (hasRoutine) {
@@ -331,7 +245,7 @@ export default function HomeScreen() {
 
     return marked;
   }, [currentDateString, storedRoutines, weekDays]);
-
+  // 시간표 하단 범례 목록 생성
   const legendItems = useMemo(() => {
     const uniqueMap = new Map<string, { label: string; dot: string }>();
 
@@ -344,12 +258,12 @@ export default function HomeScreen() {
         });
       }
     });
-
+    // 일정이 없을 때는 기본 카테고리 범례 표시
     if (uniqueMap.size === 0) {
-      Object.keys(eventTypes).forEach((key) => {
+      Object.keys(EVENT_TYPES).forEach((key) => {
         uniqueMap.set(key, {
           label: key,
-          dot: eventTypes[key as keyof typeof eventTypes].dot,
+          dot: EVENT_TYPES[key as keyof typeof EVENT_TYPES].dot,
         });
       });
     }
@@ -360,8 +274,9 @@ export default function HomeScreen() {
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.container}>
+        {/* 현재 페이지에 따라 헤더의 토글 표시 변경 */}
         <Header activeTab={activePage} />
-
+        {/* 타임테이블과 일정 화면을 가로 스와이프로 전환 */}
         <ScrollView
           horizontal
           pagingEnabled
@@ -374,12 +289,10 @@ export default function HomeScreen() {
           <View style={styles.page}>
             <View style={styles.mainCard}>
               <View style={styles.topPanel} {...panResponder.panHandlers}>
+                {/* 주간 날짜 선택 영역 */}
                 <View style={styles.daySelector}>
                   {weekDays.map((date) => {
                     const isSelected = isSameDay(date, currentDate);
-                    const isSunday = date.getDay() === 0;
-                    const isSaturday = date.getDay() === 6;
-
                     const dayStr = format(date, "E", { locale: ko });
                     const dayNum = format(date, "d");
                     return (
@@ -416,7 +329,7 @@ export default function HomeScreen() {
                     );
                   })}
                 </View>
-
+                {/* 캘린더 열기/닫기 핸들 영역 */}
                 <View style={styles.handleRow}>
                   <TouchableOpacity
                     style={styles.swipeHandleContainer}
@@ -425,7 +338,7 @@ export default function HomeScreen() {
                   >
                     <View style={styles.swipeHandle} />
                   </TouchableOpacity>
-
+                  {/* 오늘이 아닌 날짜를 보고 있을 때만 오늘 버튼 표시 */}
                   {!isSameDay(currentDate, new Date()) && (
                     <TouchableOpacity
                       style={styles.todayButton}
@@ -438,7 +351,7 @@ export default function HomeScreen() {
                     </TouchableOpacity>
                   )}
                 </View>
-
+                {/* 월간 캘린더 */}
                 {isCalendarVisible && (
                   <View style={styles.calendarWrapper}>
                     <AppCalendar
@@ -452,7 +365,7 @@ export default function HomeScreen() {
                   </View>
                 )}
               </View>
-
+              {/* 시간표 영역 */}
               <ScrollView
                 ref={timetableScrollRef}
                 style={styles.timetableContainer}
@@ -473,7 +386,7 @@ export default function HomeScreen() {
                       </View>
                     ))}
                   </View>
-
+                  {/* 시간표 그리드 영역 */}
                   <View style={styles.gridArea}>
                     {hours.map((hour) => (
                       <View
@@ -489,7 +402,7 @@ export default function HomeScreen() {
                             ]}
                           />
                         ))}
-
+                        {/* 해당 시간 줄에 걸치는 일정 블록 표시 */}
                         {timetableEvents.map((event) => {
                           const hourStart = hour * 60;
                           const hourEnd = hourStart + 60;
@@ -547,7 +460,7 @@ export default function HomeScreen() {
                             </View>
                           );
                         })}
-
+                        {/* 오늘 날짜일 때 현재 시간 위치 표시 */}
                         {isSameDay(currentDate, new Date()) &&
                           hour === currentTime.getHours() && (
                             <View
@@ -564,7 +477,7 @@ export default function HomeScreen() {
                   </View>
                 </View>
               </ScrollView>
-
+              {/* 카테고리 범례 */}
               <View style={styles.legendContainer}>
                 {legendItems.map((item) => (
                   <View key={item.label} style={styles.legendItem}>
@@ -651,9 +564,6 @@ const styles = StyleSheet.create({
   dateCircleSelected: {
     backgroundColor: "#A0B0D0",
   },
-  dayButtonContainerSelected: {
-    backgroundColor: "#EEF2FF",
-  },
   dayText: {
     fontSize: 13,
     color: "#A0A7B4",
@@ -680,12 +590,6 @@ const styles = StyleSheet.create({
     marginBottom: 6,
   },
 
-  activeDayIndicator: {
-    width: 16,
-    height: 2,
-    backgroundColor: "#405886",
-    borderRadius: 999,
-  },
   handleRow: {
     position: "relative",
     justifyContent: "center",

--- a/app/modal.tsx
+++ b/app/modal.tsx
@@ -4,6 +4,15 @@ import TimePickerModal from "@/components/time_picker_modal";
 import AppCalendar from "@/components/ui/app_calendar";
 import { IconSymbol } from "@/components/ui/icon-symbol";
 import { useRoutineForm } from "@/hooks/use_routine_form";
+import {
+  DEFAULT_CATEGORIES,
+  EVENT_TYPES,
+  getCategoryBadgeStyle,
+  normalizeHexColor,
+  uniqueColors,
+  uniqueCustomCategories,
+  type CustomCategory,
+} from "@/lib/category";
 import type {
   NotifyOption,
   RepeatType,
@@ -36,12 +45,7 @@ import ColorPicker, {
   Preview,
 } from "reanimated-color-picker";
 
-//사용자 추가 카테고리 타입
-type CustomCategory = {
-  name: string;
-  color: string;
-};
-
+// 반복 요일 선택 버튼에 사용할 요일 목록
 const WEEKDAY_OPTIONS: { label: string; value: RepeatWeekday }[] = [
   { label: "일", value: "SUN" },
   { label: "월", value: "MON" },
@@ -54,45 +58,6 @@ const WEEKDAY_OPTIONS: { label: string; value: RepeatWeekday }[] = [
 
 // 주 단위 반복은 격주까지만 허용
 const WEEK_REPEAT_EVERY_OPTIONS = ["1", "2"];
-
-const DEFAULT_CATEGORIES = [
-  "기상",
-  "운동",
-  "공부",
-  "명상",
-  "저녁",
-  "기타",
-] as const;
-
-const FIXED_EVENT_TYPES = {
-  기상: { bg: "#FAEEEE", dot: "#E79A95", text: "#5D4645" },
-  운동: { bg: "#FDF4EC", dot: "#EFB996", text: "#675141" },
-  공부: { bg: "#F1F1FB", dot: "#9FA2D6", text: "#3E426F" },
-  명상: { bg: "#F1F7EE", dot: "#A8CD9B", text: "#4C5D44" },
-  저녁: { bg: "#FEF9EE", dot: "#E6CF8A", text: "#685A3F" },
-  기타: { bg: "#F3F4F8", dot: "#C4C6D0", text: "#8A8C9A" },
-} as const;
-const isFixedCategoryName = (categoryName: string) => {
-  return Object.prototype.hasOwnProperty.call(FIXED_EVENT_TYPES, categoryName);
-};
-const getCategoryBadgeStyle = (categoryName: string, categoryColor: string) => {
-  if (isFixedCategory(categoryName)) {
-    const fixedStyle =
-      FIXED_EVENT_TYPES[categoryName as keyof typeof FIXED_EVENT_TYPES];
-
-    return {
-      backgroundColor: fixedStyle.bg,
-      textColor: fixedStyle.text,
-      borderColor: fixedStyle.dot,
-    };
-  }
-
-  return {
-    backgroundColor: `${categoryColor}22`,
-    textColor: categoryColor,
-    borderColor: categoryColor,
-  };
-};
 const DEFAULT_USER_COLOR_PALETTE = [
   "#405886",
   "#E79A95",
@@ -149,10 +114,31 @@ function formatDateLabel(dateString: string) {
   return `${year}년 ${month}월 ${day}일`;
 }
 
+// 빠른 선택의 매주/격주 반복은 시작 날짜의 요일을 기본 반복 요일로 사용
+function getWeekdayValueFromDate(dateString: string): RepeatWeekday {
+  const weekdayValues: RepeatWeekday[] = [
+    "SUN",
+    "MON",
+    "TUE",
+    "WED",
+    "THU",
+    "FRI",
+    "SAT",
+  ];
+
+  return weekdayValues[new Date(`${dateString}T00:00:00`).getDay()];
+}
+
 function getNotifyLabel(isNotify: boolean) {
   return isNotify ? "켜짐" : "꺼짐";
 }
 
+//빠른 선택 매주/격주는 시작 날짜의 요일을 보여줌
+function getQuickWeekdayLabel(startDate: string) {
+  const weekday = getWeekdayValueFromDate(startDate);
+
+  return WEEKDAY_OPTIONS.find((day) => day.value === weekday)?.label ?? "";
+}
 function getRepeatLabel(
   repeatType: RepeatType,
   repeatInterval: string,
@@ -165,14 +151,6 @@ function getRepeatLabel(
     case "DAILY":
       return "매일";
     case "CUSTOM": {
-      const unitLabelMap: Record<RepeatUnit, string> = {
-        DAY: "일",
-        WEEK: "주",
-        MONTH: "월",
-        YEAR: "년",
-      };
-
-      // 주 단위 반복은 선택한 요일까지 함께 보여줌
       if (repeatUnit === "WEEK") {
         const selectedLabels = WEEKDAY_OPTIONS.filter((day) =>
           repeatDays.includes(day.value),
@@ -185,7 +163,7 @@ function getRepeatLabel(
         return `${everyLabel}${dayLabel}`;
       }
 
-      return `${repeatInterval}${unitLabelMap[repeatUnit]}마다`;
+      return repeatInterval === "1" ? "매일" : `${repeatInterval}일마다`;
     }
     default:
       return "없음";
@@ -196,36 +174,9 @@ const REPEAT_EVERY_OPTIONS = Array.from({ length: 30 }, (_, i) =>
   String(i + 1),
 );
 
-//색상 문자열 정리
-function normalizeHexColor(color: string) {
-  return color.trim().toUpperCase();
-}
-
-//중복 색상 제거
-function uniqueColors(colors: string[]) {
-  return Array.from(new Set(colors.map(normalizeHexColor)));
-}
-
-//중복 카테고리 제거 + 이름/색상 정리
-function uniqueCustomCategories(categories: CustomCategory[]) {
-  const map = new Map<string, CustomCategory>();
-
-  categories.forEach((item) => {
-    const name = item.name.trim();
-    if (!name) return;
-
-    map.set(name, {
-      name,
-      color: normalizeHexColor(item.color),
-    });
-  });
-
-  return Array.from(map.values());
-}
-
 //기본 카테고리인지 확인
 function isFixedCategory(categoryName: string) {
-  return Object.prototype.hasOwnProperty.call(FIXED_EVENT_TYPES, categoryName);
+  return Object.prototype.hasOwnProperty.call(EVENT_TYPES, categoryName);
 }
 
 //반복 단위 선택 컬럼
@@ -327,7 +278,6 @@ function NumberOptionColumn({
 export default function ModalScreen() {
   const insets = useSafeAreaInsets();
   const router = useRouter();
-  //화면 UI 상태
   const [isAddingCategory, setIsAddingCategory] = useState(false);
   const [tempCategory, setTempCategory] = useState("");
   const [showDatePicker, setShowDatePicker] = useState(false);
@@ -530,8 +480,7 @@ export default function ModalScreen() {
     ) {
       setCategory(newCategory);
 
-      const fixedStyle =
-        FIXED_EVENT_TYPES[newCategory as keyof typeof FIXED_EVENT_TYPES];
+      const fixedStyle = EVENT_TYPES[newCategory as keyof typeof EVENT_TYPES];
       setSelectedColor(fixedStyle.dot);
 
       setTempCategory("");
@@ -607,7 +556,7 @@ export default function ModalScreen() {
 
       if (category === categoryName) {
         setCategory("기타");
-        setSelectedColor(FIXED_EVENT_TYPES["기타"].dot);
+        setSelectedColor(EVENT_TYPES["기타"].dot);
       }
     } catch (error) {
       console.error("사용자 카테고리 삭제 실패", error);
@@ -666,14 +615,28 @@ export default function ModalScreen() {
       setShowCustomRepeatModal(true);
       return;
     }
-
     setRepeatType(option);
+    setRepeatInterval("1");
+    setRepeatUnit("DAY");
+    setRepeatDays([]);
     setShowRepeatModal(false);
   };
 
-  // 반복 단위를 선택할 때 주 단위는 1주/2주까지만 허용
+  const handleSelectQuickWeeklyRepeat = (interval: "1" | "2") => {
+    setRepeatType("CUSTOM");
+    setRepeatInterval(interval);
+    setRepeatUnit("WEEK");
+    setRepeatDays([getWeekdayValueFromDate(startDate)]);
+    setShowRepeatModal(false);
+  };
+
+  // 사용자 설정 반복 단위는 일/주만 사용하고, 주 단위는 1주/2주까지만 허용
   const handleSelectCustomRepeatUnit = (unit: RepeatUnit) => {
     setRepeatUnit(unit);
+
+    if (unit === "DAY") {
+      setRepeatDays([]);
+    }
 
     if (unit === "WEEK" && Number(repeatInterval) > 2) {
       setRepeatInterval("2");
@@ -690,7 +653,7 @@ export default function ModalScreen() {
   };
 
   const handleSaveCustomRepeat = () => {
-    // 추가: 주 단위 반복은 요일을 최소 1개 선택해야 저장 가능
+    // 주 단위 반복은 요일을 최소 1개 선택해야 저장 가능
     if (repeatUnit === "WEEK" && repeatDays.length === 0) {
       Alert.alert(
         "요일 선택 필요",
@@ -734,7 +697,7 @@ export default function ModalScreen() {
     if (!repeatType || repeatType === "NONE") {
       Alert.alert(
         "반복 설정 필요",
-        "반복 설정을 선택해야 일정을 추가할 수 있어요.",
+        "반복 설정을 선택해야 루틴을 추가할 수 있어요.",
       );
       return false;
     }
@@ -782,11 +745,11 @@ export default function ModalScreen() {
       await handleSave(saveOptions);
     } catch (error) {
       if (error instanceof Error && error.message === "TIME_CONFLICT") {
-        Alert.alert("시간 중복", "같은 시간대에 이미 등록된 일정이 있어요.");
+        Alert.alert("시간 중복", "같은 시간대에 이미 등록된 루틴이 있어요.");
         return;
       }
 
-      Alert.alert("저장 실패", "일정을 저장하지 못했어요.");
+      Alert.alert("저장 실패", "루틴을 저장하지 못했어요.");
     }
   };
   //시간 모달에서 값 적용
@@ -796,6 +759,16 @@ export default function ModalScreen() {
     endHour: string;
     endMinute: string;
   }) => {
+    // 시작/종료 시간이 반대로 저장되지 않도록 적용 단계에서 먼저 차단
+    const startTotalMinutes =
+      Number(time.startHour) * 60 + Number(time.startMinute);
+    const endTotalMinutes = Number(time.endHour) * 60 + Number(time.endMinute);
+
+    if (endTotalMinutes <= startTotalMinutes) {
+      Alert.alert("시간 설정 확인", "끝나는 시간은 시작 시간보다 늦어야 해요.");
+      return;
+    }
+
     setStartHour(time.startHour);
     setStartMinute(time.startMinute);
     setEndHour(time.endHour);
@@ -885,7 +858,7 @@ export default function ModalScreen() {
 
           <View style={styles.header}>
             <ThemedText type="subtitle" style={styles.headerTitle}>
-              일정 추가
+              루틴 추가
             </ThemedText>
 
             <TouchableOpacity onPress={closeModal}>
@@ -1090,8 +1063,7 @@ export default function ModalScreen() {
               <View style={styles.categoryGrid}>
                 {categoryList.map((cat) => {
                   const resolvedCategoryColor = isFixedCategory(cat)
-                    ? FIXED_EVENT_TYPES[cat as keyof typeof FIXED_EVENT_TYPES]
-                        .dot
+                    ? EVENT_TYPES[cat as keyof typeof EVENT_TYPES].dot
                     : customCategoryColorMap[cat] ||
                       DEFAULT_USER_COLOR_PALETTE[0];
 
@@ -1231,7 +1203,7 @@ export default function ModalScreen() {
             {/* 저장 버튼 */}
             <TouchableOpacity style={styles.saveButton} onPress={handleSubmit}>
               <ThemedText style={styles.saveButtonText}>
-                일정 등록하기
+                루틴 등록하기
               </ThemedText>
             </TouchableOpacity>
           </ScrollView>
@@ -1270,15 +1242,54 @@ export default function ModalScreen() {
             <View style={styles.optionList}>
               {[
                 { label: "매일", value: "DAILY" as RepeatType },
+
+                {
+                  label: `매주(${getQuickWeekdayLabel(startDate)})`,
+                  value: "QUICK_WEEKLY",
+                },
+                {
+                  label: `격주(${getQuickWeekdayLabel(startDate)})`,
+                  value: "QUICK_BIWEEKLY",
+                },
+
                 { label: "사용자 설정", value: "CUSTOM" as RepeatType },
               ].map((item) => {
-                const isSelected = repeatType === item.value;
+                const isQuickWeekly = item.value === "QUICK_WEEKLY";
+                const isQuickBiweekly = item.value === "QUICK_BIWEEKLY";
+                const isSelected =
+                  (repeatType === "DAILY" && item.value === "DAILY") ||
+                  (repeatType === "CUSTOM" &&
+                    repeatUnit === "WEEK" &&
+                    repeatInterval === "1" &&
+                    isQuickWeekly) ||
+                  (repeatType === "CUSTOM" &&
+                    repeatUnit === "WEEK" &&
+                    repeatInterval === "2" &&
+                    isQuickBiweekly) ||
+                  (repeatType === "CUSTOM" &&
+                    !(
+                      repeatUnit === "WEEK" &&
+                      (repeatInterval === "1" || repeatInterval === "2")
+                    ) &&
+                    item.value === "CUSTOM");
 
                 return (
                   <TouchableOpacity
                     key={item.value}
                     style={styles.optionListItem}
-                    onPress={() => handleSelectRepeatType(item.value)}
+                    onPress={() => {
+                      if (isQuickWeekly) {
+                        handleSelectQuickWeeklyRepeat("1");
+                        return;
+                      }
+
+                      if (isQuickBiweekly) {
+                        handleSelectQuickWeeklyRepeat("2");
+                        return;
+                      }
+
+                      handleSelectRepeatType(item.value as RepeatType);
+                    }}
                   >
                     <ThemedText
                       style={[
@@ -1337,8 +1348,6 @@ export default function ModalScreen() {
                 options={[
                   { label: "일", value: "DAY" },
                   { label: "주", value: "WEEK" },
-                  { label: "월", value: "MONTH" },
-                  { label: "년", value: "YEAR" },
                 ]}
                 selectedValue={repeatUnit}
                 onSelect={handleSelectCustomRepeatUnit}
@@ -1512,13 +1521,6 @@ const styles = StyleSheet.create({
     fontWeight: "700",
     color: "#A0B0D0",
     marginBottom: 12,
-  },
-
-  helperText: {
-    marginTop: 10,
-    fontSize: 12,
-    color: "#A0B0D0",
-    lineHeight: 18,
   },
 
   subInput: {

--- a/app/services/routine_service.ts
+++ b/app/services/routine_service.ts
@@ -1,0 +1,19 @@
+import { RoutineStorage } from "@/lib/storage";
+import type { ScheduleRoutine } from "@/types/routine";
+
+export const RoutineService = {
+  getAll: () => RoutineStorage.getAll(),
+
+  save: (routine: ScheduleRoutine) => RoutineStorage.save(routine),
+
+  updateAll: (routines: ScheduleRoutine[]) =>
+    RoutineStorage.updateAll(routines),
+
+  updateById: (id: number, routine: Partial<ScheduleRoutine>) =>
+    RoutineStorage.updateById(id, routine),
+
+  deleteById: (id: number) => RoutineStorage.deleteById(id),
+
+  toggleComplete: (id: number, date: string) =>
+    RoutineStorage.toggleCompleteById(id, date),
+};

--- a/components/schedule_content.tsx
+++ b/components/schedule_content.tsx
@@ -1,5 +1,8 @@
+import { RoutineService } from "@/app/services/routine_service";
 import { ScheduleDetailModal } from "@/components/schedule_detail_modal";
-import { RoutineStorage } from "@/lib/storage";
+import { DEFAULT_CATEGORY_NAME, getCategoryStyle } from "@/lib/category";
+import { normalizeRepeatDays, shouldShowRoutineOnDate } from "@/lib/storage";
+
 import type {
   CalendarDay,
   RepeatWeekday,
@@ -18,38 +21,9 @@ import {
 } from "react-native";
 import AppCalendar from "./ui/app_calendar";
 
-// 카테고리 색상 타입
-type EventTypeStyle = {
-  bg: string;
-  dot: string;
-  text: string;
-};
-
 type RoutineWithCompletedDates = ScheduleRoutine & {
   completedDates?: string[];
 };
-
-const eventTypes: Record<string, EventTypeStyle> = {
-  기상: { bg: "#FAEEEE", dot: "#E79A95", text: "#5D4645" },
-  운동: { bg: "#FDF4EC", dot: "#EFB996", text: "#675141" },
-  공부: { bg: "#F1F1FB", dot: "#9FA2D6", text: "#3E426F" },
-  명상: { bg: "#F1F7EE", dot: "#A8CD9B", text: "#4C5D44" },
-  저녁: { bg: "#FEF9EE", dot: "#E6CF8A", text: "#685A3F" },
-  기타: { bg: "#F3F4F8", dot: "#C4C6D0", text: "#8A8C9A" },
-};
-
-// repeatDays가 문자열(MON,WED) 또는 배열(["MON", "WED"])로 와도 화면에서 처리되게 변환
-function normalizeRepeatDays(days?: RepeatWeekday[] | string | null) {
-  if (!days) {
-    return [];
-  }
-
-  if (Array.isArray(days)) {
-    return days;
-  }
-
-  return days.split(",").filter(Boolean) as RepeatWeekday[];
-}
 
 const weekdayLabelMap: Record<RepeatWeekday, string> = {
   SUN: "일",
@@ -61,16 +35,6 @@ const weekdayLabelMap: Record<RepeatWeekday, string> = {
   SAT: "토",
 };
 
-const weekdayValueMap: RepeatWeekday[] = [
-  "SUN",
-  "MON",
-  "TUE",
-  "WED",
-  "THU",
-  "FRI",
-  "SAT",
-];
-
 function getNotifyText(item: ScheduleRoutine) {
   return item.alarm ? "알림 있음" : "알림 없음";
 }
@@ -80,27 +44,17 @@ function getRepeatText(item: ScheduleRoutine) {
     case "DAILY":
       return "반복: 매일";
     case "CUSTOM": {
-      const unitMap = {
-        DAY: "일",
-        WEEK: "주",
-        MONTH: "개월",
-        YEAR: "년",
-      } as const;
-
       const interval = item.repeatInterval ?? 1;
       const unit = item.repeatUnit ?? "DAY";
-
       if (unit === "WEEK") {
         const repeatDays = normalizeRepeatDays(item.repeatDays);
         const dayText = repeatDays
           .map((day) => weekdayLabelMap[day])
           .join(", ");
         const weekText = interval === 2 ? "격주" : "매주";
-
         return dayText ? `반복: ${weekText} ${dayText}` : `반복: ${weekText}`;
       }
-
-      return `반복: ${interval}${unitMap[unit]}마다`;
+      return `반복: ${interval}일마다`;
     }
     case "NONE":
     default:
@@ -137,133 +91,6 @@ function parseTimeString(time?: string | null) {
   };
 }
 
-// hex 색상을 rgba로 변환하는 함수
-function hexToRgba(hex: string, alpha: number) {
-  const cleaned = hex.replace("#", "");
-
-  if (cleaned.length !== 6) {
-    return hex;
-  }
-
-  const r = parseInt(cleaned.slice(0, 2), 16);
-  const g = parseInt(cleaned.slice(2, 4), 16);
-  const b = parseInt(cleaned.slice(4, 6), 16);
-
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
-
-// 카테고리에 맞는 스타일 반환
-function getCategoryStyle(item: ScheduleRoutine): EventTypeStyle {
-  const typeLabel = item.categoryName ?? "기타";
-  const fixedStyle = eventTypes[typeLabel];
-
-  if (fixedStyle) {
-    return fixedStyle;
-  }
-
-  if (item.color) {
-    return {
-      bg: hexToRgba(item.color, 0.14),
-      dot: item.color,
-      text: item.color,
-    };
-  }
-
-  return eventTypes["기타"];
-}
-// 일 단위 차이 계산
-function getDiffDays(startDate: string, targetDate: string) {
-  const start = new Date(startDate);
-  const target = new Date(targetDate);
-
-  const startTime = new Date(
-    start.getFullYear(),
-    start.getMonth(),
-    start.getDate(),
-  ).getTime();
-
-  const targetTime = new Date(
-    target.getFullYear(),
-    target.getMonth(),
-    target.getDate(),
-  ).getTime();
-
-  return Math.floor((targetTime - startTime) / (1000 * 60 * 60 * 24));
-}
-
-// 주 단위 차이 계산
-function getDiffWeeks(startDate: string, targetDate: string) {
-  return Math.floor(getDiffDays(startDate, targetDate) / 7);
-}
-
-// 월 단위 차이 계산
-function getDiffMonths(startDate: string, targetDate: string) {
-  const start = new Date(startDate);
-  const target = new Date(targetDate);
-
-  return (
-    (target.getFullYear() - start.getFullYear()) * 12 +
-    (target.getMonth() - start.getMonth())
-  );
-}
-
-// 년 단위 차이 계산
-function getDiffYears(startDate: string, targetDate: string) {
-  const start = new Date(startDate);
-  const target = new Date(targetDate);
-
-  return target.getFullYear() - start.getFullYear();
-}
-
-// 선택 날짜에 이 일정이 보여야 하는지 판단
-function shouldShowRoutineOnDate(
-  item: ScheduleRoutine,
-  targetDateString: string,
-) {
-  if (targetDateString < item.startDate || targetDateString > item.endDate) {
-    return false;
-  }
-
-  if (!item.repeatType || item.repeatType === "NONE") {
-    return true;
-  }
-
-  if (item.repeatType === "DAILY") {
-    return true;
-  }
-
-  if (item.repeatType === "CUSTOM") {
-    const every = item.repeatInterval ?? 1;
-    const unit = item.repeatUnit ?? "DAY";
-
-    if (unit === "DAY") {
-      return getDiffDays(item.startDate, targetDateString) % every === 0;
-    }
-
-    if (unit === "WEEK") {
-      const repeatDays = normalizeRepeatDays(item.repeatDays);
-      const targetDay = weekdayValueMap[new Date(targetDateString).getDay()];
-      const isSelectedWeekday =
-        repeatDays.length === 0 || repeatDays.includes(targetDay);
-
-      return (
-        isSelectedWeekday &&
-        getDiffWeeks(item.startDate, targetDateString) % every === 0
-      );
-    }
-
-    if (unit === "MONTH") {
-      return getDiffMonths(item.startDate, targetDateString) % every === 0;
-    }
-
-    if (unit === "YEAR") {
-      return getDiffYears(item.startDate, targetDateString) % every === 0;
-    }
-  }
-
-  return false;
-}
-
 // 특정 날짜 완료 여부 확인
 function isCompletedOnDate(
   item: RoutineWithCompletedDates,
@@ -286,8 +113,11 @@ export default function ScheduleContent() {
     useState<RoutineWithCompletedDates | null>(null);
   const [showDetailModal, setShowDetailModal] = useState(false);
 
-  const selectedDateString = selectedDate.toISOString().split("T")[0];
-
+  const selectedDateString = [
+    selectedDate.getFullYear(),
+    String(selectedDate.getMonth() + 1).padStart(2, "0"),
+    String(selectedDate.getDate()).padStart(2, "0"),
+  ].join("-");
   const day = selectedDate.getDate();
   const year = selectedDate.getFullYear();
   const monthNames = [
@@ -326,13 +156,13 @@ export default function ScheduleContent() {
     setShowDatePicker(false);
   };
   const onDayPress = (day: CalendarDay) => {
-    setSelectedDate(new Date(day.dateString));
+    setSelectedDate(new Date(day.dateString + "T00:00:00")); // 로컬 시간 기준
     setShowDatePicker(false);
   };
 
   const loadRoutines = useCallback(async () => {
     try {
-      const allRoutines = await RoutineStorage.getAll();
+      const allRoutines = await RoutineService.getAll();
 
       // 선택 날짜 기준으로 보여줄 루틴만 필터링
       const filteredByDate = allRoutines.filter(
@@ -363,7 +193,7 @@ export default function ScheduleContent() {
       setTimedRoutines(timed);
       setNoTimeRoutines(noTimed);
     } catch (error) {
-      console.error("일정 불러오기 실패", error);
+      console.error("루틴 불러오기 실패", error);
       setTimedRoutines([]);
       setNoTimeRoutines([]);
     }
@@ -377,75 +207,26 @@ export default function ScheduleContent() {
 
   const toggleComplete = async (id: number) => {
     try {
-      const storageApi = RoutineStorage as unknown as {
-        getAll: () => Promise<RoutineWithCompletedDates[]>;
-        saveAll?: (routines: RoutineWithCompletedDates[]) => Promise<void>;
-        updateById?: (
-          id: number,
-          updatedRoutine: RoutineWithCompletedDates,
-        ) => Promise<void>;
-      };
-
-      const allRoutines = await storageApi.getAll();
-      const targetRoutine = allRoutines.find((item) => item.id === id);
-
-      if (!targetRoutine) {
-        return;
-      }
-
-      const prevCompletedDates = targetRoutine.completedDates ?? [];
-      const isCompletedToday = prevCompletedDates.includes(selectedDateString);
-      // 오늘 날짜를 completedDates에 추가/제거해서 완료 상태 토글
-      const nextCompletedDates = isCompletedToday
-        ? prevCompletedDates.filter((date) => date !== selectedDateString)
-        : [...prevCompletedDates, selectedDateString];
-
-      const updatedRoutine: RoutineWithCompletedDates = {
-        ...targetRoutine,
-        completedDates: nextCompletedDates,
-      };
-
-      if (storageApi.updateById) {
-        await storageApi.updateById(id, updatedRoutine);
-      } else if (storageApi.saveAll) {
-        const updatedRoutines = allRoutines.map((item) =>
-          item.id === id ? updatedRoutine : item,
-        );
-        await storageApi.saveAll(updatedRoutines);
-      } else {
-        console.error(
-          "완료 상태 변경 실패: RoutineStorage에 updateById 또는 saveAll 메서드가 필요합니다.",
-        );
-        return;
-      }
-
+      await RoutineService.toggleComplete(id, selectedDateString);
       await loadRoutines();
-
-      // 상세 모달이 열려 있을 때도 상태가 바로 반영되도록 동기화
       setSelectedRoutine((prev) => {
         if (!prev || prev.id !== id) return prev;
-
-        const prevSelectedCompletedDates = prev.completedDates ?? [];
-        const prevSelectedCompletedToday =
-          prevSelectedCompletedDates.includes(selectedDateString);
-
+        const completedDates = prev.completedDates ?? [];
+        const isCompleted = completedDates.includes(selectedDateString);
         return {
           ...prev,
-          completedDates: prevSelectedCompletedToday
-            ? prevSelectedCompletedDates.filter(
-                (date) => date !== selectedDateString,
-              )
-            : [...prevSelectedCompletedDates, selectedDateString],
+          completedDates: isCompleted
+            ? completedDates.filter((date) => date !== selectedDateString)
+            : [...completedDates, selectedDateString],
         };
       });
     } catch (error) {
       console.error("완료 상태 변경 실패", error);
     }
   };
-
   const handleDeleteRoutine = async (id: number) => {
     try {
-      await RoutineStorage.deleteById(id);
+      await RoutineService.deleteById(id);
       await loadRoutines();
 
       if (selectedRoutine?.id === id) {
@@ -453,7 +234,7 @@ export default function ScheduleContent() {
         setShowDetailModal(false);
       }
     } catch (error) {
-      console.error("일정 삭제 실패", error);
+      console.error("루틴 삭제 실패", error);
     }
   };
 
@@ -469,7 +250,7 @@ export default function ScheduleContent() {
     item: RoutineWithCompletedDates;
     isTimed: boolean;
   }) => {
-    const typeLabel = item.categoryName ?? "기타";
+    const typeLabel = item.categoryName ?? DEFAULT_CATEGORY_NAME;
     const typeStyle = getCategoryStyle(item);
     const isCompletedToday = isCompletedOnDate(item, selectedDateString);
     const parsedStartTime = parseTimeString(item.startTime);
@@ -625,7 +406,7 @@ export default function ScheduleContent() {
 
           <Text style={styles.sectionTitle}>시간 없는 루틴</Text>
           {noTimeRoutines.length === 0 ? (
-            <Text style={styles.emptyText}>시간 없는 일정이 없어요.</Text>
+            <Text style={styles.emptyText}>시간 없는 루틴이 없어요.</Text>
           ) : (
             noTimeRoutines.map((item) => (
               <RenderItem key={item.id} item={item} isTimed={false} />
@@ -636,7 +417,7 @@ export default function ScheduleContent() {
 
           <Text style={styles.sectionTitle}>시간 있는 루틴</Text>
           {timedRoutines.length === 0 ? (
-            <Text style={styles.emptyText}>시간 있는 일정이 없어요.</Text>
+            <Text style={styles.emptyText}>시간 있는 루틴이 없어요.</Text>
           ) : (
             timedRoutines.map((item) => (
               <RenderItem key={item.id} item={item} isTimed={true} />

--- a/components/schedule_detail_modal.tsx
+++ b/components/schedule_detail_modal.tsx
@@ -1,6 +1,16 @@
+import { RoutineService } from "@/app/services/routine_service";
 import { IconSymbol } from "@/components/ui/icon-symbol";
-import { RoutineStorage } from "@/lib/storage";
-import type { RepeatType, RepeatUnit, ScheduleRoutine } from "@/types/routine";
+import {
+  EVENT_TYPES,
+  getCategoryChipStyle,
+  getCategoryStyle,
+} from "@/lib/category";
+import type {
+  RepeatType,
+  RepeatUnit,
+  RepeatWeekday,
+  ScheduleRoutine,
+} from "@/types/routine";
 import { Ionicons } from "@expo/vector-icons";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
@@ -18,12 +28,6 @@ import {
 } from "react-native";
 import AppCalendar from "./ui/app_calendar";
 
-type EventTypeStyle = {
-  bg: string;
-  dot: string;
-  text: string;
-};
-
 type CustomCategory = {
   name: string;
   color: string;
@@ -31,41 +35,87 @@ type CustomCategory = {
 
 const CUSTOM_CATEGORY_STORAGE_KEY = "@rutina/custom_categories";
 
-const eventTypes: Record<string, EventTypeStyle> = {
-  기상: { bg: "#FAEEEE", dot: "#E79A95", text: "#5D4645" },
-  운동: { bg: "#FDF4EC", dot: "#EFB996", text: "#675141" },
-  공부: { bg: "#F1F1FB", dot: "#9FA2D6", text: "#3E426F" },
-  명상: { bg: "#F1F7EE", dot: "#A8CD9B", text: "#4C5D44" },
-  저녁: { bg: "#FEF9EE", dot: "#E6CF8A", text: "#685A3F" },
-  기타: { bg: "#F3F4F8", dot: "#C4C6D0", text: "#8A8C9A" },
-};
-
 type ScheduleDetailModalProps = {
   visible: boolean;
   routine: ScheduleRoutine | null;
   onClose: () => void;
   onUpdated: () => Promise<void> | void;
   onDelete?: (id: number) => Promise<void> | void;
+  readOnly?: boolean;
 };
 
 const MINUTE_OPTIONS = ["00", "10", "20", "30", "40", "50"];
+const WEEKDAY_OPTIONS: { label: string; value: RepeatWeekday }[] = [
+  { label: "일", value: "SUN" },
+  { label: "월", value: "MON" },
+  { label: "화", value: "TUE" },
+  { label: "수", value: "WED" },
+  { label: "목", value: "THU" },
+  { label: "금", value: "FRI" },
+  { label: "토", value: "SAT" },
+];
 
+const WEEK_REPEAT_EVERY_OPTIONS = ["1", "2"];
+const REPEAT_EVERY_OPTIONS = Array.from({ length: 30 }, (_, i) =>
+  String(i + 1),
+);
+
+function getWeekdayValueFromDate(dateString: string): RepeatWeekday {
+  const weekdayValues: RepeatWeekday[] = [
+    "SUN",
+    "MON",
+    "TUE",
+    "WED",
+    "THU",
+    "FRI",
+    "SAT",
+  ];
+  return weekdayValues[new Date(`${dateString}T00:00:00`).getDay()];
+}
+
+function getRepeatLabel(
+  repeatType: RepeatType,
+  repeatInterval: string,
+  repeatUnit: RepeatUnit,
+  repeatDays: RepeatWeekday[],
+): string {
+  switch (repeatType) {
+    case "NONE":
+      return "없음";
+    case "DAILY":
+      return "매일";
+    case "CUSTOM":
+      if (repeatUnit === "WEEK") {
+        const dayLabels = WEEKDAY_OPTIONS.filter((d) =>
+          repeatDays.includes(d.value),
+        ).map((d) => d.label);
+        const everyLabel = repeatInterval === "1" ? "매주" : "격주";
+        const dayLabel =
+          dayLabels.length > 0 ? ` · ${dayLabels.join(", ")}` : "";
+        return `${everyLabel}${dayLabel}`;
+      }
+      return repeatInterval === "1" ? "매일" : `${repeatInterval}일마다`;
+    default:
+      return "없음";
+  }
+}
 function getRepeatText(item: ScheduleRoutine) {
   switch (item.repeatType) {
     case "DAILY":
       return "매일 반복";
 
     case "CUSTOM": {
-      const unitMap: Record<RepeatUnit, string> = {
-        DAY: "일",
-        WEEK: "주",
-        MONTH: "개월",
-        YEAR: "년",
-      };
-      const unit = item.repeatUnit ? unitMap[item.repeatUnit] : "일";
+      if (item.repeatUnit === "WEEK") {
+        const dayLabels = WEEKDAY_OPTIONS.filter((d) =>
+          (item.repeatDays ?? []).includes(d.value),
+        ).map((d) => d.label);
+        const everyLabel = (item.repeatInterval ?? 1) === 1 ? "매주" : "격주";
+        const dayLabel =
+          dayLabels.length > 0 ? ` · ${dayLabels.join(", ")}` : "";
+        return `${everyLabel}${dayLabel} 반복`;
+      }
       const interval = item.repeatInterval ?? 1;
-
-      return `${interval}${unit}마다 반복`;
+      return interval === 1 ? "매일 반복" : `${interval}일마다 반복`;
     }
 
     case "NONE":
@@ -109,18 +159,6 @@ function formatDateRange(startDate: string, endDate: string) {
   return `${formatDate(startDate)} ~ ${formatDate(endDate)}`;
 }
 
-function hexToRgba(hex: string, alpha: number) {
-  const cleaned = hex.replace("#", "");
-
-  if (cleaned.length !== 6) return hex;
-
-  const r = parseInt(cleaned.slice(0, 2), 16);
-  const g = parseInt(cleaned.slice(2, 4), 16);
-  const b = parseInt(cleaned.slice(4, 6), 16);
-
-  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
-}
-
 function normalizeHexColor(color: string) {
   return color.trim().toUpperCase();
 }
@@ -139,42 +177,6 @@ function uniqueCustomCategories(categories: CustomCategory[]) {
   });
 
   return Array.from(map.values());
-}
-
-function getCategoryStyle(routine: ScheduleRoutine): EventTypeStyle {
-  const categoryName = routine.categoryName ?? "기타";
-  const fixedStyle = eventTypes[categoryName];
-
-  if (fixedStyle) return fixedStyle;
-
-  if (routine.color) {
-    return {
-      bg: hexToRgba(routine.color, 0.14),
-      dot: routine.color,
-      text: routine.color,
-    };
-  }
-
-  return eventTypes["기타"];
-}
-
-function getCategoryChipStyle(
-  categoryName: string,
-  customCategoryColorMap: Record<string, string>,
-): EventTypeStyle {
-  const fixedStyle = eventTypes[categoryName];
-  if (fixedStyle) return fixedStyle;
-
-  const customColor = customCategoryColorMap[categoryName];
-  if (customColor) {
-    return {
-      bg: hexToRgba(customColor, 0.14),
-      dot: customColor,
-      text: customColor,
-    };
-  }
-
-  return eventTypes["기타"];
 }
 
 function padNumber(value: number) {
@@ -247,38 +249,6 @@ function normalizeMinuteOption(minute: string) {
   return MINUTE_OPTIONS.includes(minute) ? minute : "00";
 }
 
-type DialControlProps = {
-  label: string;
-  value: string;
-  onDecrease: () => void;
-  onIncrease: () => void;
-};
-
-function DialControl({
-  label,
-  value,
-  onDecrease,
-  onIncrease,
-}: DialControlProps) {
-  return (
-    <View style={styles.dialItem}>
-      <Text style={styles.dialLabel}>{label}</Text>
-
-      <View style={styles.dialBox}>
-        <TouchableOpacity style={styles.dialButton} onPress={onDecrease}>
-          <Text style={styles.dialButtonText}>－</Text>
-        </TouchableOpacity>
-
-        <Text style={styles.dialValue}>{value}</Text>
-
-        <TouchableOpacity style={styles.dialButton} onPress={onIncrease}>
-          <Text style={styles.dialButtonText}>＋</Text>
-        </TouchableOpacity>
-      </View>
-    </View>
-  );
-}
-
 function TimeStepperControl({
   label,
   value,
@@ -317,11 +287,10 @@ export function ScheduleDetailModal({
   onClose,
   onUpdated,
   onDelete,
+  readOnly = false,
 }: ScheduleDetailModalProps) {
   const [isEditMode, setIsEditMode] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
-  const [isTogglingComplete, setIsTogglingComplete] = useState(false);
-
   const [title, setTitle] = useState("");
   const [categoryName, setCategoryName] = useState("기타");
   const [selectedColor, setSelectedColor] = useState("#C4C6D0");
@@ -341,9 +310,13 @@ export function ScheduleDetailModal({
   const [endHour, setEndHour] = useState("10");
   const [endMinute, setEndMinute] = useState("00");
 
-  const [repeatType, setRepeatType] = useState<RepeatType>("DAILY"); // 수정
-  const [repeatInterval, setRepeatInterval] = useState("1"); // 수정
-  const [repeatUnit, setRepeatUnit] = useState<RepeatUnit>("DAY"); // 수정
+  const [repeatType, setRepeatType] = useState<RepeatType>("DAILY");
+  const [repeatInterval, setRepeatInterval] = useState("1");
+  const [repeatUnit, setRepeatUnit] = useState<RepeatUnit>("DAY");
+  const [repeatDays, setRepeatDays] = useState<RepeatWeekday[]>([]);
+  const [showRepeatPanel, setShowRepeatPanel] = useState(false);
+  const [showCustomRepeatPanel, setShowCustomRepeatPanel] = useState(false);
+  const [isTimed, setIsTimed] = useState(false);
   const [isNotify, setIsNotify] = useState(false);
 
   const [customCategories, setCustomCategories] = useState<CustomCategory[]>(
@@ -362,7 +335,7 @@ export function ScheduleDetailModal({
     setShowCalendar(false);
     setTitle(targetRoutine.title);
     setCategoryName(targetRoutine.categoryName ?? "기타");
-    setSelectedColor(targetRoutine.color ?? eventTypes["기타"].dot);
+    setSelectedColor(targetRoutine.color ?? EVENT_TYPES["기타"].dot);
 
     setStartDateYear(startDateParts.year);
     setStartDateMonth(startDateParts.month);
@@ -376,11 +349,11 @@ export function ScheduleDetailModal({
     setStartMinute(normalizeMinuteOption(start.minute));
     setEndHour(end.hour);
     setEndMinute(normalizeMinuteOption(end.minute));
-
-    // 수정: repeatOption/customRepeatEvery/customRepeatUnit -> repeatType/repeatInterval/repeatUnit
     setRepeatType((targetRoutine.repeatType as RepeatType) ?? "NONE");
     setRepeatInterval(String(targetRoutine.repeatInterval ?? 1));
     setRepeatUnit((targetRoutine.repeatUnit as RepeatUnit) ?? "DAY");
+    setRepeatDays((targetRoutine.repeatDays as RepeatWeekday[]) ?? []); // ← 추가
+    setIsTimed(Boolean(targetRoutine.startTime));
     setIsNotify(Boolean(targetRoutine.alarm));
   }, []);
 
@@ -428,8 +401,6 @@ export function ScheduleDetailModal({
 
   useEffect(() => {
     if (!routine || !visible) return;
-
-    // 수정: 중복된 폼 초기화 코드를 공통 함수로 대체
     resetFormFromRoutine(routine);
   }, [routine, visible, resetFormFromRoutine]);
 
@@ -442,7 +413,7 @@ export function ScheduleDetailModal({
 
   const categoryList = useMemo(() => {
     return [
-      ...Object.keys(eventTypes),
+      ...Object.keys(EVENT_TYPES),
       ...customCategories.map((item) => item.name),
     ];
   }, [customCategories]);
@@ -460,14 +431,15 @@ export function ScheduleDetailModal({
       color: selectedColor,
       startDate: nextStartDate,
       endDate: nextEndDate,
-      startTime: makeTime(startHour, startMinute),
-      endTime: makeTime(endHour, endMinute),
+      startTime: isTimed ? makeTime(startHour, startMinute) : null,
+      endTime: isTimed ? makeTime(endHour, endMinute) : null,
       alarm: isNotify,
       repeatType,
       repeatInterval:
         repeatType === "CUSTOM" ? Number(repeatInterval || "1") : undefined,
       repeatUnit: repeatType === "CUSTOM" ? repeatUnit : undefined,
-      repeatDays: routine.repeatDays ?? [],
+      repeatDays:
+        repeatType === "CUSTOM" && repeatUnit === "WEEK" ? repeatDays : [],
     };
   }, [
     routine,
@@ -485,9 +457,11 @@ export function ScheduleDetailModal({
     endHour,
     endMinute,
     isNotify,
+    isTimed,
     repeatType,
     repeatInterval,
     repeatUnit,
+    repeatDays,
   ]);
 
   if (!routine || !previewRoutine) return null;
@@ -515,7 +489,7 @@ export function ScheduleDetailModal({
   const handleDelete = async () => {
     if (!routine || !onDelete) return;
 
-    Alert.alert("일정 삭제", "이 일정을 삭제할까요?", [
+    Alert.alert("루틴 삭제", "이 루틴을 삭제할까요?", [
       { text: "취소", style: "cancel" },
       {
         text: "삭제",
@@ -525,21 +499,71 @@ export function ScheduleDetailModal({
             await onDelete(routine.id);
             onClose();
           } catch (error) {
-            console.error("일정 삭제 실패", error);
-            Alert.alert("오류", "일정 삭제 중 문제가 발생했어요.");
+            console.error("루틴 삭제 실패", error);
+            Alert.alert("오류", "루틴 삭제 중 문제가 발생했어요.");
           }
         },
       },
     ]);
   };
+  const handleSelectQuickWeeklyRepeat = (interval: "1" | "2") => {
+    const startDateString = makeDate(
+      startDateYear,
+      startDateMonth,
+      startDateDay,
+    );
+    setRepeatType("CUSTOM");
+    setRepeatInterval(interval);
+    setRepeatUnit("WEEK");
+    setRepeatDays([getWeekdayValueFromDate(startDateString)]);
+    setShowRepeatPanel(false);
+  };
 
+  const handleSelectRepeatType = (option: RepeatType) => {
+    if (option === "CUSTOM") {
+      setShowRepeatPanel(false);
+      setShowCustomRepeatPanel(true);
+      return;
+    }
+    setRepeatType(option);
+    setRepeatInterval("1");
+    setRepeatUnit("DAY");
+    setRepeatDays([]);
+    setShowRepeatPanel(false);
+  };
+
+  const handleSelectCustomRepeatUnit = (unit: RepeatUnit) => {
+    setRepeatUnit(unit);
+    if (unit === "DAY") setRepeatDays([]);
+    if (unit === "WEEK" && Number(repeatInterval) > 2) setRepeatInterval("2");
+  };
+
+  const handleToggleWeekday = (weekday: RepeatWeekday) => {
+    setRepeatDays((prev) =>
+      prev.includes(weekday)
+        ? prev.filter((item) => item !== weekday)
+        : [...prev, weekday],
+    );
+  };
+
+  const handleSaveCustomRepeat = () => {
+    if (repeatUnit === "WEEK" && repeatDays.length === 0) {
+      Alert.alert(
+        "요일 선택 필요",
+        "주 단위 반복은 요일을 1개 이상 선택해 주세요.",
+      );
+      return;
+    }
+    setRepeatType("CUSTOM");
+    setShowCustomRepeatPanel(false);
+  };
   const handleSave = async () => {
     if (!routine) return;
 
     const trimmedTitle = title.trim();
 
     if (!trimmedTitle) {
-      Alert.alert("안내", "일정 제목을 입력해 주세요.");
+      Alert.alert("안내", "루틴 제목을 입력해 주세요.");
       return;
     }
 
@@ -561,7 +585,7 @@ export function ScheduleDetailModal({
     const startTotal = safeStartHour * 60 + safeStartMinute;
     const endTotal = safeEndHour * 60 + safeEndMinute;
 
-    if (endTotal <= startTotal) {
+    if (isTimed && endTotal <= startTotal) {
       Alert.alert("안내", "종료 시간은 시작 시간보다 늦어야 해요.");
       return;
     }
@@ -584,18 +608,24 @@ export function ScheduleDetailModal({
         Alert.alert("안내", "종료 날짜는 시작 날짜보다 빠를 수 없어요.");
         return;
       }
+      // 시간 겹침 체크
+      const newStartTime = makeTime(
+        padNumber(safeStartHour),
+        padNumber(safeStartMinute),
+      );
+      const newEndTime = makeTime(
+        padNumber(safeEndHour),
+        padNumber(safeEndMinute),
+      );
 
-      await RoutineStorage.updateById(routine.id, {
+      await RoutineService.updateById(routine.id, {
         title: trimmedTitle,
         categoryName,
         color: selectedColor,
         startDate: nextStartDate,
         endDate: nextEndDate,
-        startTime: makeTime(
-          padNumber(safeStartHour),
-          padNumber(safeStartMinute),
-        ),
-        endTime: makeTime(padNumber(safeEndHour), padNumber(safeEndMinute)),
+        startTime: isTimed ? newStartTime : null,
+        endTime: isTimed ? newEndTime : null,
         alarm: isNotify,
         repeatType,
         repeatInterval:
@@ -603,7 +633,8 @@ export function ScheduleDetailModal({
             ? clamp(Number(repeatInterval || "1"), 1, 999)
             : undefined,
         repeatUnit: repeatType === "CUSTOM" ? repeatUnit : undefined,
-        repeatDays: routine.repeatDays ?? [],
+        repeatDays:
+          repeatType === "CUSTOM" && repeatUnit === "WEEK" ? repeatDays : [],
       });
 
       await onUpdated();
@@ -611,35 +642,15 @@ export function ScheduleDetailModal({
       onClose();
     } catch (error) {
       if (error instanceof Error && error.message === "TIME_CONFLICT") {
-        Alert.alert("시간 중복", "같은 시간대에 이미 등록된 일정이 있어요.");
+        Alert.alert("시간 중복", "같은 시간대에 이미 등록된 루틴이 있어요.");
         return;
       }
 
-      console.error("일정 수정 실패", error);
-      Alert.alert("오류", "일정 수정 중 문제가 발생했어요.");
+      console.error("루틴 수정 실패", error);
+      Alert.alert("오류", "루틴 수정 중 문제가 발생했어요.");
     } finally {
       setIsSaving(false);
     }
-  };
-
-  const changeRepeatEvery = (diff: number) => {
-    const nextValue = clamp(Number(repeatInterval || "1") + diff, 1, 999);
-    setRepeatInterval(String(nextValue));
-  };
-
-  const changeRepeatUnit = (diff: number) => {
-    const units: RepeatUnit[] = ["DAY", "WEEK", "MONTH", "YEAR"];
-    const currentIndex = units.indexOf(repeatUnit);
-    const nextIndex = clamp(currentIndex + diff, 0, units.length - 1);
-
-    setRepeatUnit(units[nextIndex]);
-  };
-
-  const repeatUnitTextMap: Record<RepeatUnit, string> = {
-    DAY: "일",
-    WEEK: "주",
-    MONTH: "개월",
-    YEAR: "년",
   };
 
   return (
@@ -656,31 +667,41 @@ export function ScheduleDetailModal({
         >
           <View style={styles.detailHeader}>
             <Text style={styles.detailTitle}>
-              {isEditMode ? "일정 수정" : "상세 정보"}
+              {isEditMode ? "루틴 수정" : "상세 정보"}
             </Text>
 
             <View style={styles.headerActions}>
               {!isEditMode ? (
                 <>
-                  <TouchableOpacity
-                    onPress={handleEdit}
-                    style={styles.editButton}
-                  >
-                    <Text style={styles.editText}>수정</Text>
-                  </TouchableOpacity>
+                  {/* readOnly가 아닐 때만 수정/삭제 버튼 표시 */}
+                  {!readOnly && (
+                    <>
+                      <TouchableOpacity
+                        onPress={handleEdit}
+                        style={styles.editButton}
+                      >
+                        <Text style={styles.editText}>수정</Text>
+                      </TouchableOpacity>
 
-                  <TouchableOpacity
-                    onPress={handleDelete}
-                    style={styles.deleteIconButton}
-                  >
-                    <Ionicons name="trash-outline" size={18} color="#D45A68" />
-                  </TouchableOpacity>
+                      <TouchableOpacity
+                        onPress={handleDelete}
+                        style={styles.deleteIconButton}
+                      >
+                        <Ionicons
+                          name="trash-outline"
+                          size={18}
+                          color="#D45A68"
+                        />
+                      </TouchableOpacity>
+                    </>
+                  )}
 
                   <TouchableOpacity onPress={onClose}>
                     <IconSymbol name="xmark" size={20} color="#B4B6C0" />
                   </TouchableOpacity>
                 </>
               ) : (
+                // 편집 모드 (readOnly면 이 분기 자체에 도달 안 함)
                 <>
                   <TouchableOpacity
                     onPress={handleCancelEdit}
@@ -791,7 +812,7 @@ export function ScheduleDetailModal({
                 <TextInput
                   value={title}
                   onChangeText={setTitle}
-                  placeholder="일정 제목을 입력해 주세요"
+                  placeholder="루틴 제목을 입력해 주세요"
                   placeholderTextColor="#B4B6C0"
                   style={styles.titleInput}
                 />
@@ -928,43 +949,122 @@ export function ScheduleDetailModal({
               </View>
 
               <View style={styles.inputBlock}>
-                <Text style={styles.editSectionLabel}>시작 시간</Text>
-                <View style={styles.timePickerRow}>
-                  <TimeStepperControl
-                    label="시"
-                    value={startHour}
-                    onIncrease={() => setStartHour(getNextHour(startHour))}
-                    onDecrease={() => setStartHour(getPrevHour(startHour))}
-                  />
-                  <TimeStepperControl
-                    label="분"
-                    value={startMinute}
-                    onIncrease={() =>
-                      setStartMinute(getNextMinute(startMinute))
-                    }
-                    onDecrease={() =>
-                      setStartMinute(getPrevMinute(startMinute))
-                    }
+                <View
+                  style={{
+                    flexDirection: "row",
+                    justifyContent: "space-between",
+                    alignItems: "center",
+                    marginBottom: 10,
+                  }}
+                >
+                  <Text style={styles.editSectionLabel}>시간 설정</Text>
+                  <Switch
+                    value={isTimed}
+                    onValueChange={(value) => {
+                      setIsTimed(value);
+                      if (!value) setIsNotify(false);
+                    }}
+                    trackColor={{ true: "#9FA2D6" }}
                   />
                 </View>
-              </View>
 
-              <View style={styles.inputBlock}>
-                <Text style={styles.editSectionLabel}>종료 시간</Text>
-                <View style={styles.timePickerRow}>
-                  <TimeStepperControl
-                    label="시"
-                    value={endHour}
-                    onIncrease={() => setEndHour(getNextHour(endHour))}
-                    onDecrease={() => setEndHour(getPrevHour(endHour))}
-                  />
-                  <TimeStepperControl
-                    label="분"
-                    value={endMinute}
-                    onIncrease={() => setEndMinute(getNextMinute(endMinute))}
-                    onDecrease={() => setEndMinute(getPrevMinute(endMinute))}
-                  />
-                </View>
+                {isTimed && (
+                  <>
+                    <Text style={[styles.editSectionLabel, { marginTop: 8 }]}>
+                      시작 시간
+                    </Text>
+                    <View style={styles.timePickerRow}>
+                      <TimeStepperControl
+                        label="시"
+                        value={startHour}
+                        onIncrease={() => setStartHour(getNextHour(startHour))}
+                        onDecrease={() => setStartHour(getPrevHour(startHour))}
+                      />
+                      <TimeStepperControl
+                        label="분"
+                        value={startMinute}
+                        onIncrease={() =>
+                          setStartMinute(getNextMinute(startMinute))
+                        }
+                        onDecrease={() =>
+                          setStartMinute(getPrevMinute(startMinute))
+                        }
+                      />
+                    </View>
+
+                    <Text style={[styles.editSectionLabel, { marginTop: 12 }]}>
+                      종료 시간
+                    </Text>
+                    <View style={styles.timePickerRow}>
+                      <TimeStepperControl
+                        label="시"
+                        value={endHour}
+                        onIncrease={() => {
+                          const next = getNextHour(endHour);
+                          const startTotal =
+                            Number(startHour) * 60 + Number(startMinute);
+                          const endTotal =
+                            Number(next) * 60 + Number(endMinute);
+                          if (endTotal <= startTotal) {
+                            Alert.alert(
+                              "안내",
+                              "종료 시간은 시작 시간보다 늦어야 해요.",
+                            );
+                            return;
+                          }
+                          setEndHour(next);
+                        }}
+                        onDecrease={() => {
+                          const next = getPrevHour(endHour);
+                          const startTotal =
+                            Number(startHour) * 60 + Number(startMinute);
+                          const endTotal =
+                            Number(next) * 60 + Number(endMinute);
+                          if (endTotal <= startTotal) {
+                            Alert.alert(
+                              "안내",
+                              "종료 시간은 시작 시간보다 늦어야 해요.",
+                            );
+                            return;
+                          }
+                          setEndHour(next);
+                        }}
+                      />
+                      <TimeStepperControl
+                        label="분"
+                        value={endMinute}
+                        onIncrease={() => {
+                          const next = getNextMinute(endMinute);
+                          const startTotal =
+                            Number(startHour) * 60 + Number(startMinute);
+                          const endTotal = Number(endHour) * 60 + Number(next);
+                          if (endTotal <= startTotal) {
+                            Alert.alert(
+                              "안내",
+                              "종료 시간은 시작 시간보다 늦어야 해요.",
+                            );
+                            return;
+                          }
+                          setEndMinute(next);
+                        }}
+                        onDecrease={() => {
+                          const next = getPrevMinute(endMinute);
+                          const startTotal =
+                            Number(startHour) * 60 + Number(startMinute);
+                          const endTotal = Number(endHour) * 60 + Number(next);
+                          if (endTotal <= startTotal) {
+                            Alert.alert(
+                              "안내",
+                              "종료 시간은 시작 시간보다 늦어야 해요.",
+                            );
+                            return;
+                          }
+                          setEndMinute(next);
+                        }}
+                      />
+                    </View>
+                  </>
+                )}
               </View>
 
               <View style={styles.inputBlock}>
@@ -980,71 +1080,258 @@ export function ScheduleDetailModal({
                     </Text>
                     <Switch
                       value={isNotify}
-                      onValueChange={setIsNotify}
+                      onValueChange={(value) => {
+                        setIsNotify(value);
+                      }}
                       trackColor={{ false: "#D8DEE8", true: "#9FA2D6" }}
                     />
                   </View>
                 </View>
               </View>
-
               <View style={styles.inputBlock}>
                 <Text style={styles.editSectionLabel}>반복 설정</Text>
 
-                <View style={styles.repeatOptionWrap}>
-                  <TouchableOpacity
-                    style={[
-                      styles.repeatOptionButton,
-                      repeatType === "DAILY" &&
-                        styles.repeatOptionButtonSelected,
-                    ]}
-                    onPress={() => setRepeatType("DAILY")}
-                  >
-                    <Text
-                      style={[
-                        styles.repeatOptionText,
-                        repeatType === "DAILY" &&
-                          styles.repeatOptionTextSelected,
-                      ]}
-                    >
-                      매일 반복
-                    </Text>
-                  </TouchableOpacity>
+                {/* 현재 반복 설정 표시 버튼 */}
+                <TouchableOpacity
+                  style={styles.repeatOptionButton}
+                  onPress={() => {
+                    setShowRepeatPanel((prev) => !prev);
+                    setShowCustomRepeatPanel(false);
+                  }}
+                >
+                  <Text style={styles.repeatOptionText}>
+                    {getRepeatLabel(
+                      repeatType,
+                      repeatInterval,
+                      repeatUnit,
+                      repeatDays,
+                    )}
+                  </Text>
+                </TouchableOpacity>
 
-                  <TouchableOpacity
-                    style={[
-                      styles.repeatOptionButton,
-                      repeatType === "CUSTOM" &&
-                        styles.repeatOptionButtonSelected,
-                    ]}
-                    onPress={() => setRepeatType("CUSTOM")}
-                  >
-                    <Text
-                      style={[
-                        styles.repeatOptionText,
-                        repeatType === "CUSTOM" &&
-                          styles.repeatOptionTextSelected,
-                      ]}
-                    >
-                      사용자 설정
-                    </Text>
-                  </TouchableOpacity>
-                </View>
-                {repeatType === "CUSTOM" && (
-                  <View style={styles.customRepeatBox}>
-                    <View style={styles.dialRow}>
-                      <DialControl
-                        label="반복 수"
-                        value={repeatInterval}
-                        onDecrease={() => changeRepeatEvery(-1)}
-                        onIncrease={() => changeRepeatEvery(1)}
-                      />
-                      <DialControl
-                        label="단위"
-                        value={repeatUnitTextMap[repeatUnit]}
-                        onDecrease={() => changeRepeatUnit(-1)}
-                        onIncrease={() => changeRepeatUnit(1)}
-                      />
+                {/* 빠른 선택 패널 */}
+                {showRepeatPanel && (
+                  <View style={{ marginTop: 8, gap: 6 }}>
+                    {[
+                      { label: "매일", value: "DAILY" as RepeatType },
+                      {
+                        label: `매주 (${
+                          WEEKDAY_OPTIONS.find(
+                            (d) =>
+                              d.value ===
+                              getWeekdayValueFromDate(
+                                makeDate(
+                                  startDateYear,
+                                  startDateMonth,
+                                  startDateDay,
+                                ),
+                              ),
+                          )?.label ?? ""
+                        })`,
+                        value: "QUICK_WEEKLY",
+                      },
+                      {
+                        label: `격주 (${
+                          WEEKDAY_OPTIONS.find(
+                            (d) =>
+                              d.value ===
+                              getWeekdayValueFromDate(
+                                makeDate(
+                                  startDateYear,
+                                  startDateMonth,
+                                  startDateDay,
+                                ),
+                              ),
+                          )?.label ?? ""
+                        })`,
+                        value: "QUICK_BIWEEKLY",
+                      },
+                      { label: "사용자 설정", value: "CUSTOM" as RepeatType },
+                    ].map((item) => {
+                      const isSelected =
+                        (repeatType === "DAILY" && item.value === "DAILY") ||
+                        (repeatType === "CUSTOM" &&
+                          repeatUnit === "WEEK" &&
+                          repeatInterval === "1" &&
+                          item.value === "QUICK_WEEKLY") ||
+                        (repeatType === "CUSTOM" &&
+                          repeatUnit === "WEEK" &&
+                          repeatInterval === "2" &&
+                          item.value === "QUICK_BIWEEKLY") ||
+                        (repeatType === "CUSTOM" &&
+                          !(
+                            repeatUnit === "WEEK" &&
+                            (repeatInterval === "1" || repeatInterval === "2")
+                          ) &&
+                          item.value === "CUSTOM");
+
+                      return (
+                        <TouchableOpacity
+                          key={item.value}
+                          style={[
+                            styles.repeatOptionButton,
+                            isSelected && styles.repeatOptionButtonSelected,
+                          ]}
+                          onPress={() => {
+                            if (item.value === "QUICK_WEEKLY") {
+                              handleSelectQuickWeeklyRepeat("1");
+                            } else if (item.value === "QUICK_BIWEEKLY") {
+                              handleSelectQuickWeeklyRepeat("2");
+                            } else {
+                              handleSelectRepeatType(item.value as RepeatType);
+                            }
+                          }}
+                        >
+                          <Text
+                            style={[
+                              styles.repeatOptionText,
+                              isSelected && styles.repeatOptionTextSelected,
+                            ]}
+                          >
+                            {item.label}
+                          </Text>
+                        </TouchableOpacity>
+                      );
+                    })}
+                  </View>
+                )}
+
+                {/* 사용자 설정 패널 */}
+                {showCustomRepeatPanel && (
+                  <View style={{ marginTop: 12, gap: 14 }}>
+                    {/* 단위 - 일/주 */}
+                    <View>
+                      <Text style={styles.dialLabel}>단위</Text>
+                      <View style={{ flexDirection: "row", gap: 8 }}>
+                        {(["DAY", "WEEK"] as RepeatUnit[]).map((unit) => (
+                          <TouchableOpacity
+                            key={unit}
+                            style={[
+                              styles.repeatOptionButton,
+                              repeatUnit === unit &&
+                                styles.repeatOptionButtonSelected,
+                              { flex: 1, alignItems: "center" },
+                            ]}
+                            onPress={() => handleSelectCustomRepeatUnit(unit)}
+                          >
+                            <Text
+                              style={[
+                                styles.repeatOptionText,
+                                repeatUnit === unit &&
+                                  styles.repeatOptionTextSelected,
+                              ]}
+                            >
+                              {unit === "DAY" ? "일" : "주"}
+                            </Text>
+                          </TouchableOpacity>
+                        ))}
+                      </View>
                     </View>
+
+                    {/* 빈도 */}
+                    <View>
+                      <Text style={styles.dialLabel}>빈도</Text>
+                      {repeatUnit === "WEEK" ? (
+                        <View style={{ flexDirection: "row", gap: 8 }}>
+                          {WEEK_REPEAT_EVERY_OPTIONS.map((opt) => (
+                            <TouchableOpacity
+                              key={opt}
+                              style={[
+                                styles.repeatOptionButton,
+                                repeatInterval === opt &&
+                                  styles.repeatOptionButtonSelected,
+                                { flex: 1, alignItems: "center" },
+                              ]}
+                              onPress={() => setRepeatInterval(opt)}
+                            >
+                              <Text
+                                style={[
+                                  styles.repeatOptionText,
+                                  repeatInterval === opt &&
+                                    styles.repeatOptionTextSelected,
+                                ]}
+                              >
+                                {opt === "1" ? "매주" : "격주"}
+                              </Text>
+                            </TouchableOpacity>
+                          ))}
+                        </View>
+                      ) : (
+                        <View style={styles.frequencyGrid}>
+                          {REPEAT_EVERY_OPTIONS.slice(0, 10).map((opt) => (
+                            <TouchableOpacity
+                              key={opt}
+                              style={[
+                                styles.frequencyGridChip,
+                                repeatInterval === opt &&
+                                  styles.repeatOptionButtonSelected,
+                              ]}
+                              onPress={() => setRepeatInterval(opt)}
+                            >
+                              <Text
+                                style={[
+                                  styles.repeatOptionText,
+                                  repeatInterval === opt &&
+                                    styles.repeatOptionTextSelected,
+                                ]}
+                              >
+                                {opt}
+                              </Text>
+                            </TouchableOpacity>
+                          ))}
+                        </View>
+                      )}
+                    </View>
+
+                    {/* 요일 (주 단위일 때만) */}
+                    {repeatUnit === "WEEK" && (
+                      <View>
+                        <Text style={styles.dialLabel}>요일</Text>
+                        <View style={styles.weekdayRow}>
+                          {WEEKDAY_OPTIONS.map((day) => {
+                            const isSelected = repeatDays.includes(day.value);
+                            return (
+                              <TouchableOpacity
+                                key={day.value}
+                                style={[
+                                  styles.weekdayChip,
+                                  isSelected && styles.weekdayChipSelected,
+                                ]}
+                                onPress={() => handleToggleWeekday(day.value)}
+                              >
+                                <Text
+                                  style={[
+                                    styles.weekdayChipText,
+                                    isSelected &&
+                                      styles.weekdayChipTextSelected,
+                                  ]}
+                                >
+                                  {day.label}
+                                </Text>
+                              </TouchableOpacity>
+                            );
+                          })}
+                        </View>
+                      </View>
+                    )}
+
+                    <TouchableOpacity
+                      style={[
+                        styles.repeatOptionButton,
+                        styles.repeatOptionButtonSelected,
+                      ]}
+                      onPress={handleSaveCustomRepeat}
+                    >
+                      <Text
+                        style={[
+                          styles.repeatOptionText,
+                          styles.repeatOptionTextSelected,
+                          { textAlign: "center" },
+                        ]}
+                      >
+                        완료
+                      </Text>
+                    </TouchableOpacity>
                   </View>
                 )}
               </View>
@@ -1437,5 +1724,47 @@ const styles = StyleSheet.create({
     alignItems: "center",
     justifyContent: "center",
     backgroundColor: "#FCEBEC",
+  },
+
+  weekdayRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+  },
+  weekdayChip: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+    borderColor: "#E4E7EE",
+    backgroundColor: "#FAFBFD",
+  },
+  weekdayChipSelected: {
+    borderColor: "#405886",
+    backgroundColor: "#EEF2FF",
+  },
+  weekdayChipText: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: "#6D7690",
+  },
+  weekdayChipTextSelected: {
+    color: "#405886",
+  },
+
+  frequencyGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 6,
+  },
+  frequencyGridChip: {
+    width: "18%",
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#E4E7EE",
+    borderRadius: 14,
+    paddingVertical: 10,
+    backgroundColor: "#FAFBFD",
   },
 });

--- a/hooks/use_routine_form.ts
+++ b/hooks/use_routine_form.ts
@@ -1,5 +1,4 @@
-// hooks/use-routine-form.ts
-import { RoutineStorage } from "@/lib/storage";
+import { RoutineService } from "@/app/services/routine_service";
 import type { SaveRoutineOptions, ScheduleRoutine } from "@/types/routine";
 import { useState } from "react";
 
@@ -20,6 +19,7 @@ export const useRoutineForm = (onSuccess: () => void) => {
   // 일정 저장 함수
   const handleSave = async (options: SaveRoutineOptions) => {
     if (!title.trim()) return;
+
     const resolvedStartDate = options.startDate || selectedDate;
     const resolvedEndDate = options.endDate || selectedDate;
 
@@ -31,23 +31,26 @@ export const useRoutineForm = (onSuccess: () => void) => {
       completedDates: [],
       startDate: resolvedStartDate,
       endDate: resolvedEndDate,
-      alarm: isNotify,
+      alarm: options.notifyOption !== "NONE",
       state: true,
-      repeatOption: options.repeatOption,
-      customRepeatEvery: Number(options.customRepeatEvery || 1),
-      customRepeatUnit: options.customRepeatUnit,
-      cronExpression: null,
-
+      repeatType: options.repeatType,
+      repeatInterval:
+        options.repeatType === "CUSTOM" ? options.repeatInterval : undefined,
+      repeatUnit:
+        options.repeatType === "CUSTOM" ? options.repeatUnit : undefined,
+      repeatDays:
+        options.repeatType === "CUSTOM" && options.repeatUnit === "WEEK"
+          ? options.repeatDays
+          : null,
       ...(isTimed && {
-        startTime: `${startHour.padStart(2, "0")}:${startMinute.padStart(2, "0")}:00`,
-        endTime: `${endHour.padStart(2, "0")}:${endMinute.padStart(2, "0")}:00`,
+        startTime: `${startHour.padStart(2, "0")}:${startMinute.padStart(2, "0")}`,
+        endTime: `${endHour.padStart(2, "0")}:${endMinute.padStart(2, "0")}`,
       }),
     };
 
-    await RoutineStorage.save(newRoutine);
+    await RoutineService.save(newRoutine);
     onSuccess();
   };
-
   return {
     title,
     setTitle,

--- a/lib/category.ts
+++ b/lib/category.ts
@@ -1,0 +1,118 @@
+import type { ScheduleRoutine } from "@/types/routine";
+
+export type CustomCategory = {
+  name: string;
+  color: string;
+};
+
+export function normalizeHexColor(color: string): string {
+  const value = color.trim().toUpperCase();
+  return value.startsWith("#") ? value : `#${value}`;
+}
+
+export function uniqueColors(colors: string[]): string[] {
+  return Array.from(new Set(colors.map(normalizeHexColor)));
+}
+
+export function uniqueCustomCategories(
+  categories: CustomCategory[],
+): CustomCategory[] {
+  const map = new Map<string, CustomCategory>();
+  categories.forEach((item) => {
+    const name = item.name.trim();
+    if (!name) return;
+    map.set(name.toLowerCase(), {
+      name,
+      color: normalizeHexColor(item.color),
+    });
+  });
+  return Array.from(map.values());
+}
+
+// getCategoryBadgeStyle도 통합
+export function getCategoryBadgeStyle(
+  categoryName: string,
+  categoryColor: string,
+): { backgroundColor: string; textColor: string; borderColor: string } {
+  const fixed = EVENT_TYPES[categoryName];
+  if (fixed) {
+    return {
+      backgroundColor: fixed.bg,
+      textColor: fixed.text,
+      borderColor: fixed.dot,
+    };
+  }
+  return {
+    backgroundColor: `${categoryColor}22`,
+    textColor: categoryColor,
+    borderColor: categoryColor,
+  };
+}
+// 타입
+export type EventTypeStyle = {
+  bg: string;
+  dot: string;
+  text: string;
+};
+
+// 상수
+
+export const EVENT_TYPES: Record<string, EventTypeStyle> = {
+  기상: { bg: "#FAEEEE", dot: "#E79A95", text: "#5D4645" },
+  운동: { bg: "#FDF4EC", dot: "#EFB996", text: "#675141" },
+  공부: { bg: "#F1F1FB", dot: "#9FA2D6", text: "#3E426F" },
+  명상: { bg: "#F1F7EE", dot: "#A8CD9B", text: "#4C5D44" },
+  저녁: { bg: "#FEF9EE", dot: "#E6CF8A", text: "#685A3F" },
+  기타: { bg: "#F3F4F8", dot: "#C4C6D0", text: "#8A8C9A" },
+};
+export const DEFAULT_CATEGORIES = Object.keys(
+  EVENT_TYPES,
+) as (keyof typeof EVENT_TYPES)[];
+export const DEFAULT_CATEGORY_NAME = "기타";
+// 유틸 함수
+export function hexToRgba(hex: string, alpha: number): string {
+  const cleaned = hex.replace("#", "");
+  if (cleaned.length !== 6) return hex;
+  const r = parseInt(cleaned.slice(0, 2), 16);
+  const g = parseInt(cleaned.slice(2, 4), 16);
+  const b = parseInt(cleaned.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+}
+
+export function normalizeCategoryName(categoryName?: string | null): string {
+  const trimmed = categoryName?.trim();
+  return trimmed ? trimmed : DEFAULT_CATEGORY_NAME;
+}
+
+// 루틴 기반 스타일 반환
+export function getCategoryStyle(routine: ScheduleRoutine): EventTypeStyle {
+  const name = routine.categoryName ?? DEFAULT_CATEGORY_NAME;
+  const fixed = EVENT_TYPES[name];
+  if (fixed) return fixed;
+  if (routine.color) {
+    return {
+      bg: hexToRgba(routine.color, 0.14),
+      dot: routine.color,
+      text: routine.color,
+    };
+  }
+  return EVENT_TYPES[DEFAULT_CATEGORY_NAME];
+}
+
+// 카테고리명 + 커스텀 색상 맵 기반 스타일 반환
+export function getCategoryChipStyle(
+  categoryName: string,
+  customCategoryColorMap: Record<string, string>,
+): EventTypeStyle {
+  const fixed = EVENT_TYPES[categoryName];
+  if (fixed) return fixed;
+  const customColor = customCategoryColorMap[categoryName];
+  if (customColor) {
+    return {
+      bg: hexToRgba(customColor, 0.14),
+      dot: customColor,
+      text: customColor,
+    };
+  }
+  return EVENT_TYPES[DEFAULT_CATEGORY_NAME];
+}

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -1,4 +1,3 @@
-// lib/storage.ts
 import type {
   RepeatUnit,
   RepeatWeekday,
@@ -19,13 +18,11 @@ type StoredRoutine = Partial<ScheduleRoutine> & {
   repeatOption?: "NONE" | "DAILY" | "CUSTOM";
   customRepeatEvery?: number;
   customRepeatUnit?: RepeatUnit;
-
-  // API에서 repeatDays가 문자열로 올 수도 있어서 허용
   repeatDays?: RepeatWeekday[] | string | null;
 };
 
 // repeatDays를 항상 배열 형태로 정리
-const normalizeRepeatDays = (
+export const normalizeRepeatDays = (
   repeatDays?: RepeatWeekday[] | string | null,
 ): RepeatWeekday[] => {
   if (!repeatDays) return [];
@@ -168,7 +165,68 @@ const hasTimeConflict = (
     );
   });
 };
+export const shouldShowRoutineOnDate = (
+  item: ScheduleRoutine,
+  targetDate: string,
+): boolean => {
+  if (targetDate < item.startDate || targetDate > item.endDate) return false;
+  if (!item.repeatType || item.repeatType === "NONE") return true;
+  if (item.repeatType === "DAILY") return true;
 
+  if (item.repeatType === "CUSTOM") {
+    const every = item.repeatInterval ?? 1;
+    const unit = item.repeatUnit ?? "DAY";
+    const diffDays = Math.floor(
+      (new Date(targetDate + "T00:00:00").getTime() -
+        new Date(item.startDate + "T00:00:00").getTime()) /
+        86400000,
+    );
+
+    if (unit === "DAY") return diffDays % every === 0;
+
+    if (unit === "WEEK") {
+      if (Math.floor(diffDays / 7) % every !== 0) return false;
+      const weekdays = [
+        "SUN",
+        "MON",
+        "TUE",
+        "WED",
+        "THU",
+        "FRI",
+        "SAT",
+      ] as const;
+      const targetWeekday =
+        weekdays[new Date(targetDate + "T00:00:00").getDay()];
+      const days = normalizeRepeatDays(item.repeatDays);
+      return days.length === 0 || days.includes(targetWeekday);
+    }
+  }
+
+  return false;
+};
+
+export const getRoutineOccurrenceDates = (
+  routine: ScheduleRoutine,
+  from: string,
+  to: string,
+): string[] => {
+  const dates: string[] = [];
+  const current = new Date(from + "T00:00:00");
+  const end = new Date(to + "T00:00:00");
+
+  while (current <= end) {
+    const dateStr = [
+      current.getFullYear(),
+      String(current.getMonth() + 1).padStart(2, "0"),
+      String(current.getDate()).padStart(2, "0"),
+    ].join("-");
+
+    if (shouldShowRoutineOnDate(routine, dateStr)) dates.push(dateStr);
+    current.setDate(current.getDate() + 1);
+  }
+
+  return dates;
+};
 export const RoutineStorage = {
   getAll: async (): Promise<ScheduleRoutine[]> => {
     try {
@@ -208,20 +266,6 @@ export const RoutineStorage = {
 
       console.error("데이터 저장 실패", e);
       throw e;
-    }
-  },
-
-  // 전체 배열 저장 전용 메서드
-  saveAll: async (routines: ScheduleRoutine[]) => {
-    try {
-      const normalizedRoutines = routines.map(normalizeRoutine);
-
-      await AsyncStorage.setItem(
-        STORAGE_KEY,
-        JSON.stringify(normalizedRoutines),
-      );
-    } catch (e) {
-      console.error("전체 데이터 저장 실패", e);
     }
   },
 

--- a/types/routine.ts
+++ b/types/routine.ts
@@ -4,7 +4,7 @@ export type RepeatType = "NONE" | "DAILY" | "CUSTOM";
 
 export type RepeatOption = RepeatType;
 
-export type RepeatUnit = "DAY" | "WEEK" | "MONTH" | "YEAR";
+export type RepeatUnit = "DAY" | "WEEK";
 export type RepeatWeekday =
   | "SUN"
   | "MON"


### PR DESCRIPTION
## 관련 이슈

- Closes #39 

---

## 작업 내용

반복 설정 UI 개선

- 매주/격주 선택 시 요일 표시 추가 — 매주(월), 격주(수) 형태
- 시작 날짜 기준 반복 요일 자동 표시

카테고리 목록 전체 표시

- 루틴이 없는 카테고리도 목록에 표시되도록 수정

공유 유틸 통합 (lib/storage.ts)

- 3개 파일에서 중복 정의되던 로직을 단일 출처로 통합

카테고리 유틸 분리 (lib/category.ts)

서비스 레이어 추가 (app/services/routine_service.ts)

- RoutineStorage 직접 호출을 RoutineService로 추상화
- 컴포넌트가 스토리지 구현에 의존하지 않도록 분리
- 추후 API 전환 시 RoutineService 교체

기타
- Schedule_Detail_Modal에 readOnly prop 추가 — 통계 화면(data.tsx)에서 수정/삭제 버튼 숨김 처리

---

## 테스트 체크리스트

반복 설정
- [x]  매일 반복 선택 시 요일 칩이 표시되지 않음
- [x]  매주 반복 선택 시 요일 칩 표시, 시작 날짜 기준 요일 자동 선택
- [x]  요일 선택/해제 후 저장 시 정상 반영 확인
- [x]  매주(월), 격주(수) 형태로 UI에 올바르게 표시되는지 확인

카테고리
- [x]  종료일이 오늘보다 이전인 루틴 → 완료 탭으로 이동
- [x]  기간 내 모든 날짜의 완료 체크가 된 루틴 → 완료 탭으로 이동
- [x]  루틴이 없는 카테고리도 목록에 표시되도록 수정

readOnly 모달
 - [x] 통계 화면에서 루틴 클릭 시 수정/삭제 버튼이 노출되지 않음
 - [x] 일반 화면에서는 수정/삭제 버튼 정상 노출
---

## 참고사항

-
