### PR TITLE
feat: 카테고리 순서 변경 및 숨김·복구 서버 동기화 처리

### DIFF
--- a/app/(tabs)/category.tsx
+++ b/app/(tabs)/category.tsx
@@ -1,4 +1,5 @@
 //category.tsx
+import { DraggableCategoryList } from "@/components/DraggableCategoryList";
 import { Header } from "@/components/ui/_header";
 import {
   DEFAULT_CATEGORIES,
@@ -10,6 +11,7 @@ import {
   type CustomCategory,
 } from "@/lib/category";
 import { getRoutineOccurrenceDates } from "@/lib/storage";
+import type { Category } from "@/services/category_service";
 import { CategoryService } from "@/services/category_service";
 import { RoutineService } from "@/services/routine_service";
 import type { ScheduleRoutine } from "@/types/routine";
@@ -20,7 +22,6 @@ import {
   ActivityIndicator,
   Alert,
   Animated,
-  FlatList,
   KeyboardAvoidingView,
   Modal,
   PanResponder,
@@ -33,12 +34,12 @@ import {
   TextInput,
   View,
 } from "react-native";
+
 import ColorPicker, {
   HueSlider,
   Panel1,
   Preview,
 } from "reanimated-color-picker";
-
 // 카테고리 탭 상태 타입: 진행중 / 완료됨
 type CategoryTab = "ACTIVE" | "COMPLETED";
 
@@ -185,78 +186,51 @@ const saveCategoryMetas = async (metas: CategoryMeta[]) => {
     console.error("카테고리 메타 저장 실패", error);
   }
 };
-
-// 루틴 + 기본 카테고리 + 사용자 카테고리를 화면용 데이터로 합치기
+//서버 카테고리만 기준으로
 const buildCategorySummaries = (
   routines: ScheduleRoutine[],
   metas: CategoryMeta[],
-  customCategories: CustomCategory[],
-  serverCategoryIdMap: Record<string, number>, // 추가
+  serverCategories: Category[],
+  serverSortOrderMap: Record<number, number>,
 ): CategorySummary[] => {
   const getKey = (name: string) => normalizeCategoryName(name).toLowerCase();
   const summaryMap = new Map<string, CategorySummary>();
 
-  const presetCategories: CustomCategory[] = [
-    ...DEFAULT_CATEGORIES.map((name) => ({
-      name,
-      color: EVENT_TYPES[name].dot,
-    })),
-    ...customCategories,
-  ];
-
-  presetCategories.forEach((cat) => {
-    const key = getKey(cat.name);
-    const linkedId = serverCategoryIdMap[cat.name] ?? null;
+  // 서버에 있는 카테고리만 기준으로 목록 구성
+  serverCategories.forEach((sc) => {
+    const key = getKey(sc.name);
     summaryMap.set(key, {
       key,
-      linkedCategoryId: linkedId,
-      name: cat.name,
-      color: cat.color,
-      isHidden: false,
+      linkedCategoryId: sc.id,
+      name: sc.name,
+      color: sc.colorCode,
+      isHidden: sc.hidden,
       routines: [],
       totalCount: 0,
       completedCount: 0,
       isCompletedCategory: false,
-      isFixedCategory: isFixedCategoryName(cat.name),
+      isFixedCategory: isFixedCategoryName(sc.name),
     });
   });
 
+  // 루틴 집계
   routines.forEach((routine) => {
     const key = getKey(routine.categoryName ?? "기타");
     const existing = summaryMap.get(key);
-
     if (existing) {
       existing.routines.push(routine);
       existing.totalCount += 1;
       existing.completedCount += isRoutineCompleted(routine) ? 1 : 0;
-      if (!existing.linkedCategoryId && routine.categoryId) {
-        existing.linkedCategoryId = routine.categoryId;
-      }
-    } else {
-      summaryMap.set(key, {
-        key,
-        linkedCategoryId: routine.categoryId ?? null,
-        name: routine.categoryName ?? "기타",
-        color: routine.color ?? DEFAULT_COLOR,
-        isHidden: false,
-        routines: [routine],
-        totalCount: 1,
-        completedCount: isRoutineCompleted(routine) ? 1 : 0,
-        isCompletedCategory: false,
-        isFixedCategory: isFixedCategoryName(routine.categoryName ?? "기타"),
-      });
     }
   });
 
+  // 메타(숨김) 반영 — 서버 hidden 필드와 중복이지만 로컬 우선
   metas.forEach((meta) => {
     const key = getKey(meta.name);
     const existing = summaryMap.get(key);
     if (existing) {
       existing.isHidden = meta.isHidden;
       existing.metaId = meta.id;
-      if (!existing.linkedCategoryId && meta.linkedCategoryId) {
-        existing.linkedCategoryId = meta.linkedCategoryId;
-      }
     }
   });
 
@@ -267,11 +241,20 @@ const buildCategorySummaries = (
         category.totalCount > 0 &&
         category.completedCount === category.totalCount,
     }))
-    .sort((a, b) => a.name.localeCompare(b.name, "ko"));
+    .sort((a, b) => {
+      const orderA = serverSortOrderMap[a.linkedCategoryId!] ?? 9999;
+      const orderB = serverSortOrderMap[b.linkedCategoryId!] ?? 9999;
+      if (orderA === orderB) return a.name.localeCompare(b.name, "ko");
+      return orderA - orderB;
+    });
 };
 export default function CategoryScreen() {
   const [selectedTab, setSelectedTab] = useState<CategoryTab>("ACTIVE");
   const [routines, setRoutines] = useState<ScheduleRoutine[]>([]);
+  const [serverSortOrderMap, setServerSortOrderMap] = useState<
+    Record<number, number>
+  >({});
+  const [serverCategoryList, setServerCategoryList] = useState<Category[]>([]);
   const [categoryMetas, setCategoryMetas] = useState<CategoryMeta[]>([]);
   const [customCategories, setCustomCategories] = useState<CustomCategory[]>(
     [],
@@ -297,33 +280,40 @@ export default function CategoryScreen() {
   const refreshData = useCallback(async () => {
     try {
       setIsLoading(true);
-
       const [
         storedRoutines,
         storedMetas,
         storedCustomColors,
-        serverCategories,
+        fetchedCategories,
       ] = await Promise.all([
         loadRoutines(),
         loadCategoryMetas(),
         loadCustomColors(),
-        CategoryService.getAll(),
+        CategoryService.getAllIncludingHidden(),
       ]);
 
-      const serverCustomCategories: CustomCategory[] = serverCategories
+      console.log("서버 카테고리:", JSON.stringify(fetchedCategories));
+      console.log("서버 카테고리 개수:", fetchedCategories.length);
+      const serverCustomCategories: CustomCategory[] = fetchedCategories
         .filter((c) => !DEFAULT_CATEGORIES.includes(c.name as any))
         .map((c) => ({ name: c.name, color: c.colorCode }));
 
       const idMap: Record<string, number> = {};
-      serverCategories.forEach((c) => {
+      fetchedCategories.forEach((c) => {
         idMap[c.name] = c.id;
       });
-
+      const sortOrderMap: Record<number, number> = {};
+      fetchedCategories.forEach((c) => {
+        idMap[c.name] = c.id;
+        sortOrderMap[c.id] = c.sortOrder;
+      });
       setRoutines(storedRoutines);
       setCategoryMetas(storedMetas);
       setCustomColors(storedCustomColors);
       setCustomCategories(serverCustomCategories);
       setServerCategoryIdMap(idMap);
+      setServerSortOrderMap(sortOrderMap);
+      setServerCategoryList(fetchedCategories);
     } finally {
       setIsLoading(false);
     }
@@ -339,13 +329,13 @@ export default function CategoryScreen() {
     return buildCategorySummaries(
       routines,
       categoryMetas,
-      customCategories,
-      serverCategoryIdMap,
+      serverCategoryList,
+      serverSortOrderMap,
     );
-  }, [routines, categoryMetas, customCategories, serverCategoryIdMap]);
+  }, [routines, categoryMetas, serverCategoryList, serverSortOrderMap]);
 
   const visibleCategories = useMemo(() => {
-    return categories
+    const result = categories
       .filter((category) => !category.isHidden)
       .map((category) => {
         const filteredRoutines = category.routines.filter((routine) => {
@@ -360,6 +350,8 @@ export default function CategoryScreen() {
           isCompletedCategory: selectedTab === "COMPLETED",
         };
       });
+    console.log("visibleCategories 개수:", result.length);
+    return result;
   }, [categories, selectedTab]);
 
   const hiddenCategories = useMemo(() => {
@@ -655,8 +647,8 @@ export default function CategoryScreen() {
           let targetId = editingCategory.linkedCategoryId ?? null;
 
           if (!targetId) {
-            const serverCategories = await CategoryService.getAll();
-            const matched = serverCategories.find(
+            const freshCategories = await CategoryService.getAll();
+            const matched = freshCategories.find(
               (c) =>
                 c.name.trim().toLowerCase() ===
                 editingCategory.name.trim().toLowerCase(),
@@ -683,20 +675,28 @@ export default function CategoryScreen() {
     }
   };
 
-  // 카테고리 숨김 — 서버 + 로컬 메타 동기화
+  // 카테고리 숨김 — 서버 실패 시 중단
   const handleHideCategory = async (category: CategorySummary) => {
+    // 서버 ID가 있으면 서버 먼저 업데이트
     if (category.linkedCategoryId) {
       try {
         await CategoryService.update(category.linkedCategoryId, {
-          name: category.name, // ← 기존 이름 함께 전송
-          colorCode: category.color, // ← 기존 색상 함께 전송
+          name: category.name,
+          colorCode: category.color,
           hidden: true,
         });
       } catch (error) {
+        // ✅ 서버 실패 시 로컬 업데이트 없이 중단
         console.error("서버 카테고리 숨김 처리 실패", error);
+        Alert.alert(
+          "숨기기 실패",
+          "서버 연결에 문제가 생겼어요. 잠시 후 다시 시도해주세요.",
+        );
+        return; // ← 핵심: 여기서 종료
       }
     }
 
+    // 서버 성공(또는 서버 ID 없는 경우)에만 로컬 메타 업데이트
     await upsertCategoryMeta((prev) => {
       const now = new Date().toISOString();
       const matchedIndex = prev.findIndex((meta) => {
@@ -729,20 +729,27 @@ export default function CategoryScreen() {
     await refreshData();
   };
 
-  // 숨긴 카테고리 복구 — 서버 + 로컬 메타 동기화
+  // 숨긴 카테고리 복구 — 서버 실패 시 중단
   const handleRestoreCategory = async (category: CategorySummary) => {
     if (category.linkedCategoryId) {
       try {
         await CategoryService.update(category.linkedCategoryId, {
-          name: category.name, // ← 기존 이름 함께 전송
-          colorCode: category.color, // ← 기존 색상 함께 전송
+          name: category.name,
+          colorCode: category.color,
           hidden: false,
         });
       } catch (error) {
+        // ✅ 서버 실패 시 로컬 업데이트 없이 중단
         console.error("서버 카테고리 복구 실패", error);
+        Alert.alert(
+          "복구 실패",
+          "서버 연결에 문제가 생겼어요. 잠시 후 다시 시도해주세요.",
+        );
+        return; // ← 핵심
       }
     }
 
+    // 서버 성공에만 로컬 메타 업데이트
     await upsertCategoryMeta((prev) =>
       prev.map((meta) => {
         const isMatched =
@@ -800,8 +807,8 @@ export default function CategoryScreen() {
     if (category.linkedCategoryId) return category.linkedCategoryId;
 
     // 숨겨진 카테고리까지 포함해서 서버에서 전체 목록을 가져와 매칭
-    const serverCategories = await CategoryService.getAllIncludingHidden();
-    const matched = serverCategories.find(
+    const allCategories = await CategoryService.getAllIncludingHidden();
+    const matched = allCategories.find(
       (item) =>
         normalizeCategoryName(item.name).toLowerCase() ===
         normalizeCategoryName(category.name).toLowerCase(),
@@ -866,6 +873,32 @@ export default function CategoryScreen() {
       },
     ]);
   };
+  // 카테고리 순서 변경 — 낙관적 업데이트 후 서버 동기화, 실패 시 롤백
+  const handleReorder = async (reorderedCategories: CategorySummary[]) => {
+    const categoryIds = reorderedCategories
+      .filter((c) => c.linkedCategoryId != null)
+      .map((c) => c.linkedCategoryId as number);
+
+    if (categoryIds.length === 0) return;
+
+    // 롤백용으로 현재 순서 저장
+    const previousSortOrderMap = { ...serverSortOrderMap };
+
+    // ✅ 낙관적 업데이트: 서버 응답 전에 로컬 상태 먼저 반영
+    const newSortOrderMap: Record<number, number> = {};
+    categoryIds.forEach((id, index) => {
+      newSortOrderMap[id] = index;
+    });
+    setServerSortOrderMap(newSortOrderMap);
+
+    try {
+      await CategoryService.reorder(categoryIds);
+    } catch (error) {
+      console.error("순서 변경 실패 — 롤백");
+
+      setServerSortOrderMap(previousSortOrderMap);
+    }
+  };
   const renderRoutineItem = (routine: ScheduleRoutine) => {
     const completed = isRoutineCompleted(routine);
 
@@ -896,72 +929,81 @@ export default function CategoryScreen() {
     );
   };
   // 카테고리 카드 한 개를 렌더링
-  const renderCategoryCard = ({ item }: { item: CategorySummary }) => {
-    const badgeText = selectedTab === "COMPLETED" ? "완료됨" : "진행중";
-    const badgeStyle =
-      selectedTab === "COMPLETED" ? styles.badgeCompleted : undefined;
-    const badgeTextStyle =
-      selectedTab === "COMPLETED" ? styles.badgeTextCompleted : undefined;
+  const renderCategoryItem = useCallback(
+    (item: CategorySummary, index: number) => {
+      const badgeText = selectedTab === "COMPLETED" ? "완료됨" : "진행중";
+      const badgeStyle =
+        selectedTab === "COMPLETED" ? styles.badgeCompleted : undefined;
+      const badgeTextStyle =
+        selectedTab === "COMPLETED" ? styles.badgeTextCompleted : undefined;
 
-    return (
-      <View style={styles.card}>
-        <View style={styles.cardHeaderRow}>
-          <View style={styles.cardTitleRow}>
-            <View style={[styles.colorDot, { backgroundColor: item.color }]} />
-            <View style={styles.cardTitleTextBox}>
-              <Text style={styles.cardTitle}>{item.name}</Text>
-              <Text style={styles.cardCountText}>
-                전체 {item.totalCount}개 · 완료 {item.completedCount}개
+      return (
+        <View style={styles.card}>
+          {/* 드래그 힌트 */}
+          <View style={styles.dragHandle}>
+            <Text style={styles.dragHandleText}>⠿</Text>
+          </View>
+
+          <View style={styles.cardHeaderRow}>
+            <View style={styles.cardTitleRow}>
+              <View
+                style={[styles.colorDot, { backgroundColor: item.color }]}
+              />
+              <View style={styles.cardTitleTextBox}>
+                <Text style={styles.cardTitle}>{item.name}</Text>
+                <Text style={styles.cardCountText}>
+                  전체 {item.totalCount}개 · 완료 {item.completedCount}개
+                </Text>
+              </View>
+            </View>
+            <View style={[styles.badge, badgeStyle]}>
+              <Text style={[styles.badgeText, badgeTextStyle]}>
+                {badgeText}
               </Text>
             </View>
           </View>
 
-          <View style={[styles.badge, badgeStyle]}>
-            <Text style={[styles.badgeText, badgeTextStyle]}>{badgeText}</Text>
+          <View style={styles.routineBox}>
+            {item.routines.length > 0 ? (
+              item.routines.slice(0, 3).map(renderRoutineItem)
+            ) : (
+              <Text style={styles.emptyRoutineText}>
+                {selectedTab === "ACTIVE"
+                  ? "연결된 루틴이 아직 없어요."
+                  : "완료된 루틴이 아직 없어요."}
+              </Text>
+            )}
+          </View>
+
+          <View style={styles.actionRow}>
+            <Pressable
+              style={[styles.actionButton, styles.editButton]}
+              onPress={() => openEditCategoryModal(item)}
+            >
+              <Text style={[styles.actionButtonText, styles.editButtonText]}>
+                수정
+              </Text>
+            </Pressable>
+            <Pressable
+              style={[styles.actionButton, styles.hideButton]}
+              onPress={() => handleHideCategory(item)}
+            >
+              <Text style={styles.actionButtonText}>숨기기</Text>
+            </Pressable>
+            <Pressable
+              style={[styles.actionButton, styles.deleteButton]}
+              onPress={() => handleDeleteCategory(item)}
+            >
+              <Text style={[styles.actionButtonText, styles.deleteButtonText]}>
+                삭제
+              </Text>
+            </Pressable>
           </View>
         </View>
-
-        <View style={styles.routineBox}>
-          {item.routines.length > 0 ? (
-            item.routines.slice(0, 3).map(renderRoutineItem)
-          ) : (
-            <Text style={styles.emptyRoutineText}>
-              {selectedTab === "ACTIVE"
-                ? "연결된 루틴이 아직 없어요."
-                : "완료된 루틴이 아직 없어요."}
-            </Text>
-          )}
-        </View>
-
-        <View style={styles.actionRow}>
-          <Pressable
-            style={[styles.actionButton, styles.editButton]}
-            onPress={() => openEditCategoryModal(item)}
-          >
-            <Text style={[styles.actionButtonText, styles.editButtonText]}>
-              수정
-            </Text>
-          </Pressable>
-
-          <Pressable
-            style={[styles.actionButton, styles.hideButton]}
-            onPress={() => handleHideCategory(item)}
-          >
-            <Text style={styles.actionButtonText}>숨기기</Text>
-          </Pressable>
-
-          <Pressable
-            style={[styles.actionButton, styles.deleteButton]}
-            onPress={() => handleDeleteCategory(item)}
-          >
-            <Text style={[styles.actionButtonText, styles.deleteButtonText]}>
-              삭제
-            </Text>
-          </Pressable>
-        </View>
-      </View>
-    );
-  };
+      );
+    },
+    [selectedTab],
+  );
 
   const renderHiddenCard = (item: CategorySummary) => {
     return (
@@ -1047,11 +1089,10 @@ export default function CategoryScreen() {
               <Text style={styles.loadingText}>카테고리를 불러오는 중...</Text>
             </View>
           ) : (
-            <FlatList
+            <DraggableCategoryList
               data={visibleCategories}
-              keyExtractor={(item) => item.key}
-              renderItem={renderCategoryCard}
-              showsVerticalScrollIndicator={false}
+              renderItem={renderCategoryItem}
+              onReorder={handleReorder}
               style={styles.list}
               contentContainerStyle={styles.listContent}
               ListEmptyComponent={
@@ -1099,6 +1140,7 @@ export default function CategoryScreen() {
             />
           )}
         </View>
+
         {/* 카테고리 추가/수정 바텀시트 모달 */}
         <Modal
           visible={isCategoryModalVisible}
@@ -1392,7 +1434,6 @@ const styles = StyleSheet.create({
     backgroundColor: "#FFFFFF",
     borderRadius: 30,
     borderColor: "#EEF1F6",
-    overflow: "hidden",
   },
 
   headerArea: {
@@ -1943,5 +1984,17 @@ const styles = StyleSheet.create({
   keyboardAvoidingView: {
     flex: 1,
     justifyContent: "flex-end",
+  },
+  dragHandle: {
+    position: "absolute",
+    top: 16,
+    right: 16,
+    padding: 4,
+    zIndex: 1,
+  },
+  dragHandleText: {
+    fontSize: 18,
+    color: "#C4C6D0",
+    letterSpacing: 1,
   },
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -19,8 +19,8 @@ import { useColorScheme } from "@/hooks/use-color-scheme";
 import { authStore } from "@/store/authStore";
 import { useFonts } from "expo-font";
 import { useEffect, useState } from "react";
-
-// 스플래시 화면이 자동으로 숨겨지는 것을 방지합니다.
+import { GestureHandlerRootView } from "react-native-gesture-handler";
+// 스플래시 화면이 자동으로 숨겨지는 것을 방지
 SplashScreen.preventAutoHideAsync();
 
 export const unstable_settings = {
@@ -102,38 +102,40 @@ export default function RootLayout() {
   }
 
   return (
-    <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="settings" options={{ headerShown: false }} />
-        <Stack.Screen
-          name="onboarding/login"
-          options={{ headerShown: false }}
-        />
-        <Stack.Screen
-          name="onboarding/signup"
-          options={{ headerShown: false }}
-        />
-        <Stack.Screen
-          name="onboarding/signup2"
-          options={{ headerShown: false }}
-        />
-        <Stack.Screen
-          name="onboarding/[terms]"
-          options={{ headerShown: false }}
-        />
-        <Stack.Screen
-          name="modal"
-          options={{
-            presentation: "transparentModal",
-            headerShown: false,
-            gestureEnabled: true,
-            animation: "slide_from_bottom",
-          }}
-        />
-      </Stack>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <ThemeProvider value={colorScheme === "dark" ? DarkTheme : DefaultTheme}>
+        <Stack>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="settings" options={{ headerShown: false }} />
+          <Stack.Screen
+            name="onboarding/login"
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name="onboarding/signup"
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name="onboarding/signup2"
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name="onboarding/[terms]"
+            options={{ headerShown: false }}
+          />
+          <Stack.Screen
+            name="modal"
+            options={{
+              presentation: "transparentModal",
+              headerShown: false,
+              gestureEnabled: true,
+              animation: "slide_from_bottom",
+            }}
+          />
+        </Stack>
 
-      <StatusBar style="auto" />
-    </ThemeProvider>
+        <StatusBar style="auto" />
+      </ThemeProvider>
+    </GestureHandlerRootView>
   );
 }

--- a/components/DraggableCategoryList.tsx
+++ b/components/DraggableCategoryList.tsx
@@ -1,0 +1,379 @@
+// components/DraggableCategoryList.tsx
+import React, { useCallback, useEffect, useRef, useState } from "react";
+import { FlatList, LayoutChangeEvent, StyleSheet, View } from "react-native";
+import { Gesture, GestureDetector } from "react-native-gesture-handler";
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useSharedValue,
+  withSpring,
+  type SharedValue,
+} from "react-native-reanimated";
+
+export interface DraggableItem {
+  key: string;
+  [key: string]: any;
+}
+
+interface Props<T extends DraggableItem> {
+  data: T[];
+  renderItem: (item: T, index: number) => React.ReactNode;
+  onReorder: (newData: T[]) => void;
+  ListFooterComponent?: React.ReactElement;
+  ListEmptyComponent?: React.ReactElement;
+  style?: any;
+  contentContainerStyle?: any;
+}
+
+function DraggableRow<T extends DraggableItem>({
+  item,
+  index,
+  draggingIndex,
+  hoverIndex,
+  dragY,
+  draggedHeight,
+  onLayout,
+  onDragStart,
+  onDragUpdate,
+  onDragEnd,
+  renderItem,
+}: {
+  item: T;
+  index: number;
+  draggingIndex: number | null;
+  hoverIndex: number | null;
+  dragY: SharedValue<number>;
+  draggedHeight: number;
+  onLayout: (index: number, e: LayoutChangeEvent) => void;
+  onDragStart: (index: number, absoluteY: number) => void;
+  onDragUpdate: (absoluteY: number) => void;
+  onDragEnd: () => void;
+  renderItem: (item: T, index: number) => React.ReactNode;
+}) {
+  const isDraggingThis = draggingIndex === index;
+
+  const gesture = React.useMemo(
+    () =>
+      Gesture.Pan()
+        .activateAfterLongPress(400)
+        .onStart((e) => {
+          "worklet";
+          runOnJS(onDragStart)(index, e.absoluteY);
+        })
+        .onUpdate((e) => {
+          "worklet";
+          runOnJS(onDragUpdate)(e.absoluteY);
+        })
+        .onEnd(() => {
+          "worklet";
+          runOnJS(onDragEnd)();
+        })
+        .onFinalize(() => {
+          "worklet";
+          runOnJS(onDragEnd)();
+        }),
+    [index, onDragStart, onDragUpdate, onDragEnd],
+  );
+
+  const animatedStyle = useAnimatedStyle(() => {
+    if (isDraggingThis) {
+      return {
+        transform: [{ translateY: dragY.value }],
+        zIndex: 999,
+        opacity: 0.95,
+        shadowOpacity: 0.18,
+        elevation: 8,
+      };
+    }
+
+    if (draggingIndex === null || hoverIndex === null) {
+      return {
+        transform: [
+          { translateY: withSpring(0, { damping: 20, stiffness: 200 }) },
+        ],
+        zIndex: 1,
+        opacity: 1,
+      };
+    }
+
+    const from = draggingIndex;
+    const to = hoverIndex;
+
+    if (from > to && index >= to && index < from) {
+      return {
+        transform: [
+          {
+            translateY: withSpring(draggedHeight, {
+              damping: 20,
+              stiffness: 200,
+            }),
+          },
+        ],
+        zIndex: 1,
+        opacity: 1,
+      };
+    }
+
+    if (from < to && index > from && index <= to) {
+      return {
+        transform: [
+          {
+            translateY: withSpring(-draggedHeight, {
+              damping: 20,
+              stiffness: 200,
+            }),
+          },
+        ],
+        zIndex: 1,
+        opacity: 1,
+      };
+    }
+
+    return {
+      transform: [
+        { translateY: withSpring(0, { damping: 20, stiffness: 200 }) },
+      ],
+      zIndex: 1,
+      opacity: 1,
+    };
+  });
+
+  return (
+    <GestureDetector gesture={gesture}>
+      <Animated.View
+        onLayout={(e) => onLayout(index, e)}
+        style={[isDraggingThis && styles.draggingCard, animatedStyle]}
+      >
+        {renderItem(item, index)}
+      </Animated.View>
+    </GestureDetector>
+  );
+}
+
+export function DraggableCategoryList<T extends DraggableItem>({
+  data,
+  renderItem,
+  onReorder,
+  ListFooterComponent,
+  ListEmptyComponent,
+  style,
+  contentContainerStyle,
+}: Props<T>) {
+  const [items, setItems] = useState<T[]>(data);
+  const [draggingIndex, setDraggingIndex] = useState<number | null>(null);
+  const [hoverIndex, setHoverIndex] = useState<number | null>(null);
+  const [draggedHeight, setDraggedHeight] = useState(200);
+
+  const itemHeights = useRef<number[]>([]);
+  const itemOffsets = useRef<number[]>([]);
+  const scrollOffsetY = useRef(0);
+  const listTopY = useRef(0);
+  const listHeight = useRef(0);
+  const itemsRef = useRef<T[]>(data);
+  const draggingIndexRef = useRef<number | null>(null);
+  const hoverIndexRef = useRef<number | null>(null);
+  const startAbsoluteYRef = useRef(0);
+  const isEndedRef = useRef(false);
+  const flatListRef = useRef<FlatList>(null);
+  const containerRef = useRef<View>(null); // ← View ref로 measure
+  const autoScrollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const dragY = useSharedValue(0);
+  const isDragging = useSharedValue(false);
+
+  useEffect(() => {
+    if (draggingIndex === null) {
+      // 드래그 종료 후 500ms 이내엔 외부 data 변경 무시
+      if (Date.now() - lastReorderTime.current < 500) return;
+      setItems([...data]);
+      itemsRef.current = data;
+    }
+  }, [data, draggingIndex]);
+  const stopAutoScroll = useCallback(() => {
+    if (autoScrollTimer.current) {
+      clearInterval(autoScrollTimer.current);
+      autoScrollTimer.current = null;
+    }
+  }, []);
+
+  const startAutoScroll = useCallback(
+    (direction: "up" | "down") => {
+      stopAutoScroll();
+      autoScrollTimer.current = setInterval(() => {
+        scrollOffsetY.current += direction === "down" ? 8 : -8;
+        if (scrollOffsetY.current < 0) scrollOffsetY.current = 0;
+        flatListRef.current?.scrollToOffset({
+          offset: scrollOffsetY.current,
+          animated: false,
+        });
+      }, 16);
+    },
+    [stopAutoScroll],
+  );
+
+  const updateOffsets = useCallback((heights: number[]) => {
+    const offsets: number[] = [];
+    let acc = 0;
+    for (const h of heights) {
+      offsets.push(acc);
+      acc += h;
+    }
+    itemOffsets.current = offsets;
+  }, []);
+
+  const onItemLayout = useCallback(
+    (index: number, e: LayoutChangeEvent) => {
+      itemHeights.current[index] = e.nativeEvent.layout.height;
+      updateOffsets(itemHeights.current);
+    },
+    [updateOffsets],
+  );
+
+  const getIndexFromY = useCallback((absoluteY: number): number => {
+    const relY = absoluteY - listTopY.current + scrollOffsetY.current;
+    const offsets = itemOffsets.current;
+    const heights = itemHeights.current;
+    for (let i = 0; i < offsets.length; i++) {
+      const top = offsets[i];
+      const bottom = top + (heights[i] ?? 200);
+      if (relY >= top && relY < bottom) return i;
+    }
+    if (relY < 0) return 0;
+    return itemsRef.current.length - 1;
+  }, []);
+
+  const handleDragStart = useCallback(
+    (index: number, absoluteY: number) => {
+      isEndedRef.current = false;
+      draggingIndexRef.current = index;
+      hoverIndexRef.current = index;
+      startAbsoluteYRef.current = absoluteY;
+      dragY.value = 0;
+      isDragging.value = true;
+      setDraggedHeight(itemHeights.current[index] ?? 200);
+      setDraggingIndex(index);
+      setHoverIndex(index);
+    },
+    [dragY, isDragging],
+  );
+
+  const handleDragUpdate = useCallback(
+    (absoluteY: number) => {
+      dragY.value = absoluteY - startAbsoluteYRef.current;
+
+      const listBottom = listTopY.current + listHeight.current;
+      const scrollZone = 80;
+      if (absoluteY > listBottom - scrollZone) {
+        startAutoScroll("down");
+      } else if (absoluteY < listTopY.current + scrollZone) {
+        startAutoScroll("up");
+      } else {
+        stopAutoScroll();
+      }
+
+      const newHover = getIndexFromY(absoluteY);
+      if (newHover !== hoverIndexRef.current) {
+        hoverIndexRef.current = newHover;
+        setHoverIndex(newHover);
+      }
+    },
+    [dragY, getIndexFromY, startAutoScroll, stopAutoScroll],
+  );
+  const lastReorderTime = useRef<number>(0);
+  const handleDragEnd = useCallback(() => {
+    if (isEndedRef.current) return;
+    isEndedRef.current = true;
+
+    stopAutoScroll();
+
+    const from = draggingIndexRef.current;
+    const to = hoverIndexRef.current;
+    console.log("from:", from, "to:", to);
+    console.log(
+      "현재 내부 순서:",
+      itemsRef.current.map((item) => item.name),
+    );
+    isDragging.value = false;
+    dragY.value = withSpring(0, { damping: 20, stiffness: 200 });
+
+    if (from !== null && to !== null && from !== to) {
+      const currentItems = [...itemsRef.current];
+      const [moved] = currentItems.splice(from, 1);
+      currentItems.splice(to, 0, moved);
+
+      itemsRef.current = currentItems;
+      setItems(currentItems);
+      onReorder(currentItems);
+    }
+    setDraggingIndex(null);
+    setHoverIndex(null);
+    draggingIndexRef.current = null;
+    hoverIndexRef.current = null;
+    lastReorderTime.current = Date.now();
+  }, [onReorder, isDragging, dragY, stopAutoScroll]);
+
+  return (
+    <View
+      ref={containerRef}
+      style={style}
+      onLayout={(e) => {
+        listHeight.current = e.nativeEvent.layout.height;
+        containerRef.current?.measure(
+          (
+            _x: number,
+            _y: number,
+            _w: number,
+            _h: number,
+            _px: number,
+            py: number,
+          ) => {
+            listTopY.current = py;
+          },
+        );
+      }}
+    >
+      <FlatList
+        ref={flatListRef}
+        data={items}
+        keyExtractor={(item) => item.key}
+        style={{ flex: 1 }}
+        contentContainerStyle={contentContainerStyle}
+        showsVerticalScrollIndicator={false}
+        scrollEnabled={draggingIndex === null}
+        onScroll={(e) => {
+          scrollOffsetY.current = e.nativeEvent.contentOffset.y;
+        }}
+        scrollEventThrottle={16}
+        ListEmptyComponent={ListEmptyComponent}
+        ListFooterComponent={ListFooterComponent}
+        renderItem={({ item, index }) => (
+          <DraggableRow
+            key={item.key}
+            item={item}
+            index={index}
+            draggingIndex={draggingIndex}
+            hoverIndex={hoverIndex}
+            dragY={dragY}
+            draggedHeight={draggedHeight}
+            onLayout={onItemLayout}
+            onDragStart={handleDragStart}
+            onDragUpdate={handleDragUpdate}
+            onDragEnd={handleDragEnd}
+            renderItem={renderItem}
+          />
+        )}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  draggingCard: {
+    shadowColor: "#233255",
+    shadowOpacity: 0.18,
+    shadowRadius: 16,
+    shadowOffset: { width: 0, height: 6 },
+    elevation: 8,
+    borderRadius: 20,
+  },
+});

--- a/lib/data/api.ts
+++ b/lib/data/api.ts
@@ -1,4 +1,4 @@
-// lib/api.ts
+// lib/data/api.ts
 import apiClient from "./api_client";
 
 export const api = async (

--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -3089,7 +3088,6 @@
       "resolved": "https://registry.npmjs.org/@react-navigation/native/-/native-7.1.33.tgz",
       "integrity": "sha512-DpFdWGcgLajKZ1TuIvDNQsblN2QaUFWpTQaB8v7WRP9Mix8H/6TFoIrZd93pbymI2hybd6UYrD+lI408eWVcfw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@react-navigation/core": "^7.16.1",
         "escape-string-regexp": "^4.0.0",
@@ -3314,7 +3312,6 @@
       "integrity": "sha512-Qec1E3mhALmaspIrhWt9jkQMNdw6bReVu64mjvhbhq2NFPftLPVr+l1SZgmw/66WwBNpDh7ao5AT6gF5v41PFA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.0.2"
       }
@@ -3385,7 +3382,6 @@
       "integrity": "sha512-XZzOmihLIr8AD1b9hL9ccNMzEMWt/dE2u7NyTY9jJG6YNiNthaD5XtUHVF2uCXZ15ng+z2hT3MVuxnUYhq6k1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.0",
         "@typescript-eslint/types": "8.57.0",
@@ -3973,7 +3969,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4697,7 +4692,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5693,7 +5687,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5890,7 +5883,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6129,7 +6121,6 @@
       "resolved": "https://registry.npmjs.org/expo/-/expo-54.0.34.tgz",
       "integrity": "sha512-XkVHguZZDC8BcTQxHAd14/TQFbDp1Wt0Z/KApO9t68Ll5A127hLCPzU+a9gytfCIiyL/V1IpF1vIcOLKEVAoNQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.20.0",
         "@expo/cli": "54.0.24",
@@ -6206,7 +6197,6 @@
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.13.tgz",
       "integrity": "sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@expo/config": "~12.0.13",
         "@expo/env": "~2.0.8"
@@ -6231,7 +6221,6 @@
       "resolved": "https://registry.npmjs.org/expo-font/-/expo-font-14.0.11.tgz",
       "integrity": "sha512-ga0q61ny4s/kr4k8JX9hVH69exVSIfcIc19+qZ7gt71Mqtm7xy2c6kwsPTCyhBW2Ro5yXTT8EaZOpuRi35rHbg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fontfaceobserver": "^2.1.0"
       },
@@ -6282,7 +6271,6 @@
       "resolved": "https://registry.npmjs.org/expo-linking/-/expo-linking-8.0.12.tgz",
       "integrity": "sha512-FpXeIpFgZuxihwT9lBo86YD3y6LphBuAhN680MMxm/Y7fmsc57vimn2d3vFu68VI0+Z9w457t494mu2wvlgWTQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "expo-constants": "~18.0.13",
         "invariant": "^2.2.4"
@@ -10425,7 +10413,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10445,7 +10432,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
       "integrity": "sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.26.0"
       },
@@ -10482,7 +10468,6 @@
       "resolved": "https://registry.npmjs.org/react-native/-/react-native-0.81.5.tgz",
       "integrity": "sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^29.7.0",
         "@react-native/assets-registry": "0.81.5",
@@ -10561,7 +10546,6 @@
       "resolved": "https://registry.npmjs.org/react-native-gesture-handler/-/react-native-gesture-handler-2.28.0.tgz",
       "integrity": "sha512-0msfJ1vRxXKVgTgvL+1ZOoYw3/0z1R+Ked0+udoJhyplC2jbVKIJ8Z1bzWdpQRCV3QcQ87Op0zJVE5DhKK2A0A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@egjs/hammerjs": "^2.0.17",
         "hoist-non-react-statics": "^3.3.0",
@@ -10615,7 +10599,6 @@
       "resolved": "https://registry.npmjs.org/react-native-safe-area-context/-/react-native-safe-area-context-5.6.2.tgz",
       "integrity": "sha512-4XGqMNj5qjUTYywJqpdWZ9IG8jgkS3h06sfVjfw5yZQZfWnRFXczi0GnYyFyCc2EBps/qFmoCH8fez//WumdVg==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "*",
         "react-native": "*"
@@ -10626,7 +10609,6 @@
       "resolved": "https://registry.npmjs.org/react-native-screens/-/react-native-screens-4.16.0.tgz",
       "integrity": "sha512-yIAyh7F/9uWkOzCi1/2FqvNvK6Wb9Y1+Kzn16SuGfN9YFJDTbwlzGRvePCNTOX0recpLQF3kc2FmvMUhyTCH1Q==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "react-freeze": "^1.0.0",
         "react-native-is-edge-to-edge": "^1.2.1",
@@ -10648,7 +10630,6 @@
       "resolved": "https://registry.npmjs.org/react-native-web/-/react-native-web-0.21.2.tgz",
       "integrity": "sha512-SO2t9/17zM4iEnFvlu2DA9jqNbzNhoUP+AItkoCOyFmDMOhUnBBznBDCYN92fGdfAkfQlWzPoez6+zLxFNsZEg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.6",
         "@react-native/normalize-colors": "^0.74.1",
@@ -10791,7 +10772,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.2.tgz",
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -12116,7 +12096,6 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12329,7 +12308,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"


### PR DESCRIPTION
## 관련 이슈

- Closes #54 
- Closes #53 
---

## 작업 내용

 카테고리 순서 변경 기능 구현
 - DraggableCategoryList.tsx 신규 구현
  - Gesture.Pan() 롱프레스(400ms) 후 드래그 활성화
  - useSharedValue/useAnimatedStyle로 드래그 애니메이션 처리
  - withSpring으로 인접 카드 밀려나는 애니메이션 적용
  - 리스트 경계 근처 자동 스크롤 처리
  
handleReorder 구현
  - 낙관적 업데이트로 서버 응답 전 UI 반영

카테고리 숨김·복구 서버 미반영 케이스 처리
- handleHideCategory/handleRestoreCategory 서버 실패 시
  로컬 메타 업데이트 차단 (return으로 즉시 종료)
- 서버 실패 시 Alert 표시로 사용자에게 실패 안내
- refreshData에서 getAll() → getAllIncludingHidden()으로 변경
  숨긴 카테고리도 목록에 포함하여 UI에 정상 표시
---

## 테스트 체크리스트

- [x] 드래그 후 순서 반영 및 서버 저장 확인
- [x] 카테고리 숨기기 후 숨긴 카테고리 섹션에 표시 확인
- [x] 카테고리 복구 후 진행중 목록 복귀 확인
---

## 참고사항

- 숨긴 카테고리는 순서 변경 대상에서 제외됨
- 로컬 메타가 서버 hidden 필드보다 우선 적용되는 구조
