### PR TITLE
feat: 루틴 추가 모달 UX 개선 및 시간 입력 컴포넌트 분리

### DIFF
--- a/app/modal.tsx
+++ b/app/modal.tsx
@@ -5,14 +5,7 @@ import TimePickerModal from "@/components/time_picker_modal";
 import AppCalendar from "@/components/ui/app_calendar";
 import { IconSymbol } from "@/components/ui/icon-symbol";
 import { useRoutineForm } from "@/hooks/use_routine_form";
-import {
-  DEFAULT_CATEGORIES,
-  EVENT_TYPES,
-  getCategoryBadgeStyle,
-  normalizeHexColor,
-  uniqueColors,
-  type CustomCategory,
-} from "@/lib/category";
+import { EVENT_TYPES, type CustomCategory } from "@/lib/category";
 import { CategoryService } from "@/services/category_service";
 import type {
   NotifyOption,
@@ -40,11 +33,6 @@ import {
 } from "react-native";
 import { DateData } from "react-native-calendars";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import ColorPicker, {
-  HueSlider,
-  Panel1,
-  Preview,
-} from "reanimated-color-picker";
 
 // 반복 요일 선택 버튼에 사용할 요일 목록
 const WEEKDAY_OPTIONS: { label: string; value: RepeatWeekday }[] = [
@@ -59,23 +47,13 @@ const WEEKDAY_OPTIONS: { label: string; value: RepeatWeekday }[] = [
 
 // 주 단위 반복은 격주까지만 허용
 const WEEK_REPEAT_EVERY_OPTIONS = ["1", "2"];
-const DEFAULT_USER_COLOR_PALETTE = [
-  "#405886",
-  "#E79A95",
-  "#EFB996",
-  "#9FA2D6",
-  "#A8CD9B",
-  "#C4C6D0",
-];
 
-//AsyncStorage key
-const CUSTOM_COLOR_STORAGE_KEY = "@rutina/custom_colors";
-const CUSTOM_CATEGORY_STORAGE_KEY = "@rutina/custom_categories";
 //공통 색상 상수
 const FIXED_PRIMARY_COLOR = "#405886";
 const FIXED_SWITCH_COLOR = "#9FA2D6";
 const CALENDAR_SELECTED_COLOR = "#405886";
-
+//미저장 루틴/카테고리 캐시 저장
+const DRAFT_STORAGE_KEY = "@rutina/routine_draft";
 //캘린더 테마
 const CALENDAR_THEME = {
   backgroundColor: "#F8F9FB",
@@ -286,18 +264,13 @@ export default function ModalScreen() {
     category?: string;
     description?: string;
   }>();
-  const [isAddingCategory, setIsAddingCategory] = useState(false);
-  const [tempCategory, setTempCategory] = useState("");
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [showTimeModal, setShowTimeModal] = useState(false);
   const [showRepeatModal, setShowRepeatModal] = useState(false);
   const [showCustomRepeatModal, setShowCustomRepeatModal] = useState(false);
-  const [customColors, setCustomColors] = useState<string[]>([]);
   const [customCategories, setCustomCategories] = useState<CustomCategory[]>(
     [],
   );
-  const [showColorPickerModal, setShowColorPickerModal] = useState(false);
-  const [pickerColor, setPickerColor] = useState("#405886");
   const [activeDateField, setActiveDateField] = useState<"start" | "end">(
     "start",
   );
@@ -328,6 +301,8 @@ export default function ModalScreen() {
     setIsNotify,
     handleSave,
   } = useRoutineForm(() => router.dismiss());
+  const [startDate, setStartDate] = useState(selectedDate);
+  const [endDate, setEndDate] = useState(selectedDate);
 
   // AI 추천 데이터 연동
   useEffect(() => {
@@ -354,9 +329,37 @@ export default function ModalScreen() {
       setIsTimed(true);
     }
   }, [params]);
+  useEffect(() => {
+    // AI 추천 파라미터가 있으면 draft 복원 스킵
+    if (params.title || params.category || params.startTime || params.endTime)
+      return;
 
-  const [startDate, setStartDate] = useState(selectedDate);
-  const [endDate, setEndDate] = useState(selectedDate);
+    const loadDraft = async () => {
+      try {
+        const stored = await AsyncStorage.getItem(DRAFT_STORAGE_KEY);
+        if (!stored) return;
+        const draft = JSON.parse(stored);
+
+        if (draft.title) setTitle(draft.title);
+        if (draft.category) setCategory(draft.category);
+        if (draft.startDate) setStartDate(draft.startDate);
+        if (draft.endDate) setEndDate(draft.endDate);
+        if (draft.repeatType) setRepeatType(draft.repeatType);
+        if (draft.repeatInterval) setRepeatInterval(draft.repeatInterval);
+        if (draft.repeatUnit) setRepeatUnit(draft.repeatUnit);
+        if (draft.repeatDays) setRepeatDays(draft.repeatDays);
+        if (typeof draft.isTimed === "boolean") setIsTimed(draft.isTimed);
+        if (draft.startHour) setStartHour(draft.startHour);
+        if (draft.startMinute) setStartMinute(draft.startMinute);
+        if (draft.endHour) setEndHour(draft.endHour);
+        if (draft.endMinute) setEndMinute(draft.endMinute);
+      } catch (error) {
+        console.error("draft 복원 실패", error);
+      }
+    };
+
+    loadDraft();
+  }, []);
 
   useEffect(() => {
     // form 훅의 기준 날짜를 시작 날짜와 맞춰줌
@@ -369,7 +372,7 @@ export default function ModalScreen() {
   const customNotifyHour = "0";
   const customNotifyMinute = "0";
   //반복 설정 상태
-  const [repeatType, setRepeatType] = useState<RepeatType>("NONE");
+  const [repeatType, setRepeatType] = useState<RepeatType>("DAILY");
   const [repeatInterval, setRepeatInterval] = useState("1");
   const [repeatUnit, setRepeatUnit] = useState<RepeatUnit>("DAY");
   // 주 단위 사용자 반복에서 선택한 요일 저장
@@ -385,12 +388,8 @@ export default function ModalScreen() {
 
   //전체 카테고리 목록
   const categoryList = useMemo(() => {
-    return [
-      ...DEFAULT_CATEGORIES,
-      ...customCategories.map((item) => item.name),
-    ];
+    return customCategories.map((item) => item.name);
   }, [customCategories]);
-
   //선택 날짜 표시
   const markedDates = useMemo(() => {
     if (startDate === endDate) {
@@ -427,29 +426,6 @@ export default function ModalScreen() {
     return endDate < startDate;
   }, [startDate, endDate]);
 
-  //저장된 사용자 색상 불러오기
-  useEffect(() => {
-    const loadCustomColors = async () => {
-      try {
-        const stored = await AsyncStorage.getItem(CUSTOM_COLOR_STORAGE_KEY);
-
-        if (!stored) {
-          setCustomColors([]);
-          return;
-        }
-
-        const parsed = JSON.parse(stored) as string[];
-        const normalized = uniqueColors(parsed);
-        setCustomColors(normalized);
-      } catch (error) {
-        console.error("사용자 색상 불러오기 실패", error);
-        setCustomColors([]);
-      }
-    };
-
-    loadCustomColors();
-  }, []);
-
   //날짜 선택
   const handleDayPress = (day: DateData) => {
     if (activeDateField === "start") {
@@ -475,94 +451,36 @@ export default function ModalScreen() {
       });
   }, []);
 
-  //카테고리 저장
-  const handleCategorySave = async () => {
-    const newCategory = tempCategory.trim();
-    if (!newCategory) return;
+  const saveDraftRef = useRef<() => Promise<void>>(async () => {});
 
-    // 기본 카테고리면 서버 저장 없이 선택만
-    if (DEFAULT_CATEGORIES.includes(newCategory as any)) {
-      setCategory(newCategory);
-      const fixedStyle = EVENT_TYPES[newCategory as keyof typeof EVENT_TYPES];
-      setSelectedColor(fixedStyle.dot);
-      setTempCategory("");
-      setIsAddingCategory(false);
-      return;
-    }
-
-    try {
-      // 서버에 저장
-      await CategoryService.create(
-        newCategory,
-        normalizeHexColor(selectedColor),
-      );
-
-      // 서버에서 최신 목록 다시 불러오기
-      const serverCategories = await CategoryService.getAll();
-      const custom = serverCategories
-        .filter((c) => !Object.keys(EVENT_TYPES).includes(c.name))
-        .map((c) => ({ name: c.name, color: c.colorCode }));
-      setCustomCategories(custom);
-
-      setCategory(newCategory);
-      setSelectedColor(normalizeHexColor(selectedColor));
-      setTempCategory("");
-      setIsAddingCategory(false);
-    } catch (error: any) {
-      if (error?.response?.status === 409) {
-        // 이미 존재하는 카테고리면 그냥 선택
-        setCategory(newCategory);
-        setTempCategory("");
-        setIsAddingCategory(false);
-      } else {
-        console.error("카테고리 저장 실패", error);
-        Alert.alert("카테고리 저장 실패", "카테고리를 저장하지 못했어요.");
-      }
-    }
-  };
-
-  const handleCategoryCancel = () => {
-    setTempCategory("");
-    setIsAddingCategory(false);
-  };
-  //커스텀 카테고리 삭제 확인
-  const handleDeleteCustomCategory = async (categoryName: string) => {
-    try {
-      // 서버 ID 찾기
-      const serverCategories = await CategoryService.getAll();
-      const matched = serverCategories.find(
-        (c) =>
-          c.name.trim().toLowerCase() === categoryName.trim().toLowerCase(),
-      );
-
-      if (matched) {
-        await CategoryService.delete(matched.id);
-      }
-
-      // 삭제 후 목록 갱신
-      const updated = await CategoryService.getAll();
-      const custom = updated
-        .filter((c) => !Object.keys(EVENT_TYPES).includes(c.name))
-        .map((c) => ({ name: c.name, color: c.colorCode }));
-      setCustomCategories(custom);
-
-      if (category === categoryName) {
-        setCategory("기타");
-        setSelectedColor(EVENT_TYPES["기타"].dot);
-      }
-    } catch (error) {
-      console.error("카테고리 삭제 실패", error);
-      Alert.alert("카테고리 삭제 실패", "카테고리를 삭제하지 못했어요.");
-    }
+  saveDraftRef.current = async () => {
+    const draft = {
+      title,
+      category,
+      startDate,
+      endDate,
+      repeatType,
+      repeatInterval,
+      repeatUnit,
+      repeatDays,
+      isTimed,
+      startHour,
+      startMinute,
+      endHour,
+      endMinute,
+    };
+    await AsyncStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
   };
   //모달 닫기 애니메이션
   const closeModal = () => {
-    Animated.timing(translateY, {
-      toValue: 500,
-      duration: 180,
-      useNativeDriver: true,
-    }).start(() => {
-      router.dismiss();
+    saveDraftRef.current().then(() => {
+      Animated.timing(translateY, {
+        toValue: 500,
+        duration: 180,
+        useNativeDriver: true,
+      }).start(() => {
+        router.dismiss();
+      });
     });
   };
 
@@ -590,7 +508,15 @@ export default function ModalScreen() {
       },
       onPanResponderRelease: (_, gestureState) => {
         if (gestureState.dy > closeThreshold) {
-          closeModal();
+          saveDraftRef.current?.().then(() => {
+            Animated.timing(translateY, {
+              toValue: 500,
+              duration: 180,
+              useNativeDriver: true,
+            }).start(() => {
+              router.dismiss();
+            });
+          });
         } else {
           resetSheetPosition();
         }
@@ -735,6 +661,7 @@ export default function ModalScreen() {
 
     try {
       await handleSave(saveOptions);
+      await AsyncStorage.removeItem(DRAFT_STORAGE_KEY);
     } catch (error: any) {
       const status = error?.response?.status;
       if (status === 409) {
@@ -769,67 +696,6 @@ export default function ModalScreen() {
     setShowTimeModal(false);
   };
 
-  //색상 저장
-  const handleSavePickedColor = async () => {
-    try {
-      const nextColors = uniqueColors([pickerColor, ...customColors]).slice(
-        0,
-        16,
-      );
-
-      await AsyncStorage.setItem(
-        CUSTOM_COLOR_STORAGE_KEY,
-        JSON.stringify(nextColors),
-      );
-
-      setCustomColors(nextColors);
-      setSelectedColor(normalizeHexColor(pickerColor));
-      setShowColorPickerModal(false);
-    } catch (error) {
-      console.error("사용자 색상 저장 실패", error);
-      Alert.alert("색상 저장 실패", "색상을 저장하지 못했어요.");
-    }
-  };
-
-  const handleConfirmDeleteCustomColor = (color: string) => {
-    Alert.alert(
-      "색상 삭제",
-      "이 색상을 삭제할까요?",
-      [
-        {
-          text: "취소",
-          style: "cancel",
-        },
-        {
-          text: "삭제",
-          style: "destructive",
-          onPress: () => {
-            handleDeleteCustomColor(color);
-          },
-        },
-      ],
-      { cancelable: true },
-    );
-  };
-  //커스텀 색상 삭제
-  const handleDeleteCustomColor = async (color: string) => {
-    try {
-      const filtered = customColors.filter((item) => item !== color);
-
-      await AsyncStorage.setItem(
-        CUSTOM_COLOR_STORAGE_KEY,
-        JSON.stringify(filtered),
-      );
-
-      setCustomColors(filtered);
-
-      if (selectedColor === color) {
-        setSelectedColor(DEFAULT_USER_COLOR_PALETTE[0]);
-      }
-    } catch (error) {
-      console.error("사용자 색상 삭제 실패", error);
-    }
-  };
   return (
     <ThemedView style={styles.overlay}>
       <Pressable style={styles.backdrop} onPress={closeModal} />
@@ -875,7 +741,6 @@ export default function ModalScreen() {
               value={title}
               onChangeText={setTitle}
               placeholderTextColor="#B4B6C0"
-              autoFocus
             />
             {/* 시작/종료 날짜 선택 */}
             <View style={styles.section}>
@@ -968,141 +833,54 @@ export default function ModalScreen() {
                 </View>
               )}
             </View>
-
-            {/* 사용자 색상 선택 */}
-            <View style={styles.section}>
-              <View style={styles.rowBetween}>
-                <ThemedText style={styles.label}>사용자 색상</ThemedText>
-              </View>
-
-              <View style={styles.colorRowWrap}>
-                {DEFAULT_USER_COLOR_PALETTE.map((color) => (
-                  <TouchableOpacity
-                    key={`default-${color}`}
-                    style={[
-                      styles.colorDot,
-                      { backgroundColor: color },
-                      selectedColor === color && styles.colorDotActive,
-                    ]}
-                    onPress={() => setSelectedColor(color)}
-                  />
-                ))}
-                {customColors.map((color) => (
-                  <View key={`custom-${color}`} style={styles.colorItem}>
-                    <TouchableOpacity
-                      style={[
-                        styles.colorDot,
-                        { backgroundColor: color },
-                        selectedColor === color && styles.colorDotActive,
-                      ]}
-                      onPress={() => setSelectedColor(color)}
-                      onLongPress={() => handleConfirmDeleteCustomColor(color)}
-                    />
-
-                    <View style={styles.colorDeleteMiniButton}>
-                      <IconSymbol name="minus" size={10} color="#FFFFFF" />
-                    </View>
-                  </View>
-                ))}
-
-                <TouchableOpacity
-                  style={styles.plusColorCircle}
-                  onPress={() => {
-                    setPickerColor(selectedColor || "#405886");
-                    setShowColorPickerModal(true);
-                  }}
-                >
-                  <IconSymbol name="plus" size={18} color="#405886" />
-                </TouchableOpacity>
-              </View>
-            </View>
             {/* 카테고리 선택 */}
-            <View style={styles.section}>
-              <View style={styles.rowBetween}>
+            {categoryList.length > 0 && (
+              <View style={styles.section}>
                 <ThemedText style={styles.label}>카테고리</ThemedText>
+                <View style={styles.categoryGrid}>
+                  {categoryList.map((cat) => {
+                    const resolvedColor =
+                      customCategoryColorMap[cat] ?? "#405886";
+                    const isSelected = category === cat;
 
-                {!isAddingCategory ? (
-                  <TouchableOpacity onPress={() => setIsAddingCategory(true)}>
-                    <ThemedText style={styles.addText}>+ 추가</ThemedText>
-                  </TouchableOpacity>
-                ) : (
-                  <View style={styles.categoryActionRow}>
-                    <TouchableOpacity
-                      onPress={handleCategoryCancel}
-                      style={styles.categoryActionButton}
-                    >
-                      <ThemedText style={styles.cancelText}>취소</ThemedText>
-                    </TouchableOpacity>
-
-                    <TouchableOpacity
-                      onPress={handleCategorySave}
-                      style={styles.categoryActionButton}
-                    >
-                      <ThemedText style={styles.saveText}>저장</ThemedText>
-                    </TouchableOpacity>
-                  </View>
-                )}
-              </View>
-              {isAddingCategory && (
-                <TextInput
-                  style={styles.subInput}
-                  placeholder="새 카테고리 이름"
-                  value={tempCategory}
-                  onChangeText={setTempCategory}
-                  placeholderTextColor="#B4B6C0"
-                />
-              )}
-
-              <View style={styles.categoryGrid}>
-                {categoryList.map((cat) => {
-                  const resolvedCategoryColor = isFixedCategory(cat)
-                    ? EVENT_TYPES[cat as keyof typeof EVENT_TYPES].dot
-                    : customCategoryColorMap[cat] ||
-                      DEFAULT_USER_COLOR_PALETTE[0];
-
-                  const badgeStyle = getCategoryBadgeStyle(
-                    cat,
-                    resolvedCategoryColor,
-                  );
-                  const isSelected = category === cat;
-
-                  return (
-                    <TouchableOpacity
-                      key={cat}
-                      style={[
-                        styles.categoryBadge,
-                        {
-                          backgroundColor: badgeStyle.backgroundColor,
-                          borderColor: isSelected
-                            ? badgeStyle.borderColor
-                            : "transparent",
-                          borderWidth: isSelected ? 1.5 : 1,
-                        },
-                      ]}
-                      onPress={() => {
-                        setCategory(cat);
-                        setSelectedColor(resolvedCategoryColor);
-                      }}
-                    >
-                      <View
+                    return (
+                      <TouchableOpacity
+                        key={cat}
                         style={[
-                          styles.categoryBadgeDot,
-                          { backgroundColor: resolvedCategoryColor },
+                          styles.categoryBadge,
+                          {
+                            backgroundColor: resolvedColor + "22",
+                            borderColor: isSelected
+                              ? resolvedColor
+                              : "transparent",
+                            borderWidth: isSelected ? 1.5 : 1,
+                          },
                         ]}
-                      />
-                      <ThemedText
-                        style={[
-                          styles.categoryBadgeText,
-                          { color: badgeStyle.textColor },
-                        ]}
+                        onPress={() => {
+                          setCategory(cat);
+                          setSelectedColor(resolvedColor);
+                        }}
                       >
-                        {cat}
-                      </ThemedText>
-                    </TouchableOpacity>
-                  );
-                })}
+                        <View
+                          style={[
+                            styles.categoryBadgeDot,
+                            { backgroundColor: resolvedColor },
+                          ]}
+                        />
+                        <ThemedText
+                          style={[
+                            styles.categoryBadgeText,
+                            { color: resolvedColor },
+                          ]}
+                        >
+                          {cat}
+                        </ThemedText>
+                      </TouchableOpacity>
+                    );
+                  })}
+                </View>
               </View>
-            </View>
+            )}
             {/* 시간 / 알림 / 반복 설정 카드 */}
             <View style={styles.optionCard}>
               <View style={styles.rowBetween}>
@@ -1387,51 +1165,6 @@ export default function ModalScreen() {
           </Pressable>
         </Pressable>
       )}
-
-      {/* 사용자 색상 선택 모달 */}
-      {showColorPickerModal && (
-        <Pressable
-          style={styles.inlineModalOverlay}
-          onPress={() => setShowColorPickerModal(false)}
-        >
-          <Pressable
-            style={styles.colorPickerCard}
-            onPress={(e) => e.stopPropagation()}
-          >
-            <View style={styles.inlineModalHeader}>
-              <ThemedText style={styles.inlineModalTitle}>색상 추가</ThemedText>
-
-              <TouchableOpacity onPress={handleSavePickedColor}>
-                <ThemedText style={styles.inlineModalDone}>저장</ThemedText>
-              </TouchableOpacity>
-            </View>
-
-            <ColorPicker
-              value={pickerColor}
-              onCompleteJS={(color) => {
-                setPickerColor(color.hex);
-              }}
-              style={styles.colorPicker}
-            >
-              <Preview hideInitialColor style={styles.colorPreview} />
-              <Panel1 style={styles.colorPanel} />
-              <HueSlider style={styles.hueSlider} />
-            </ColorPicker>
-
-            <View style={styles.selectedColorInfoRow}>
-              <View
-                style={[
-                  styles.selectedColorPreviewDot,
-                  { backgroundColor: pickerColor },
-                ]}
-              />
-              <ThemedText style={styles.selectedColorHexText}>
-                {pickerColor.toUpperCase()}
-              </ThemedText>
-            </View>
-          </Pressable>
-        </Pressable>
-      )}
     </ThemedView>
   );
 }
@@ -1516,15 +1249,6 @@ const styles = StyleSheet.create({
     marginBottom: 12,
   },
 
-  subInput: {
-    backgroundColor: "#F8F9FB",
-    padding: 12,
-    borderRadius: 12,
-    fontSize: 15,
-    color: "#2A3C6B",
-    marginBottom: 10,
-  },
-
   selectorButton: {
     backgroundColor: "#F8F9FB",
     paddingHorizontal: 14,
@@ -1563,79 +1287,6 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-  },
-
-  colorRowWrap: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 14,
-    alignItems: "center",
-  },
-
-  colorItem: {
-    position: "relative",
-  },
-
-  colorDot: {
-    width: 30,
-    height: 30,
-    borderRadius: 15,
-  },
-
-  colorDotActive: {
-    borderWidth: 3,
-    borderColor: "#2A3C6B",
-  },
-
-  colorDeleteMiniButton: {
-    position: "absolute",
-    right: -4,
-    top: -4,
-    width: 16,
-    height: 16,
-    borderRadius: 8,
-    backgroundColor: "#D06C68",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-
-  plusColorCircle: {
-    width: 30,
-    height: 30,
-    borderRadius: 15,
-    borderWidth: 1.5,
-    borderColor: "#D7DEEA",
-    backgroundColor: "#F8F9FB",
-    justifyContent: "center",
-    alignItems: "center",
-  },
-
-  addText: {
-    color: "#405886",
-    fontSize: 13,
-    fontWeight: "700",
-  },
-
-  categoryActionRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 14,
-  },
-
-  categoryActionButton: {
-    paddingVertical: 2,
-  },
-
-  cancelText: {
-    color: "#8A8C9A",
-    fontSize: 13,
-    fontWeight: "700",
-  },
-
-  saveText: {
-    color: "#405886",
-    fontSize: 13,
-    fontWeight: "800",
   },
 
   categoryGrid: {
@@ -1766,14 +1417,6 @@ const styles = StyleSheet.create({
     width: "100%",
     maxWidth: 360,
     maxHeight: "70%",
-    backgroundColor: "#FFFFFF",
-    borderRadius: 24,
-    padding: 18,
-  },
-
-  colorPickerCard: {
-    width: "100%",
-    maxWidth: 360,
     backgroundColor: "#FFFFFF",
     borderRadius: 24,
     padding: 18,
@@ -1923,46 +1566,6 @@ const styles = StyleSheet.create({
     color: "#FFFFFF",
   },
 
-  colorPicker: {
-    width: "100%",
-  },
-
-  colorPreview: {
-    marginBottom: 16,
-  },
-
-  colorPanel: {
-    width: "100%",
-    height: 180,
-    borderRadius: 16,
-    marginBottom: 16,
-  },
-
-  hueSlider: {
-    width: "100%",
-    height: 36,
-    borderRadius: 12,
-    marginBottom: 16,
-  },
-
-  selectedColorInfoRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 10,
-    marginTop: 4,
-  },
-
-  selectedColorPreviewDot: {
-    width: 24,
-    height: 24,
-    borderRadius: 12,
-  },
-
-  selectedColorHexText: {
-    fontSize: 14,
-    fontWeight: "700",
-    color: "#405886",
-  },
   dateRangeColumn: {
     gap: 10,
   },

--- a/components/schedule_detail_modal.tsx
+++ b/components/schedule_detail_modal.tsx
@@ -671,14 +671,13 @@ export function ScheduleDetailModal({
       setIsSaving(false);
     }
   };
-
   return (
     <Modal visible={visible} transparent animationType="fade">
-      <Pressable style={styles.detailOverlay} onPress={onClose}>
-        <KeyboardAvoidingView
-          behavior={Platform.OS === "ios" ? "padding" : undefined}
-          style={{ width: "100%", alignItems: "center" }}
-        >
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        style={{ flex: 1 }}
+      >
+        <Pressable style={styles.detailOverlay} onPress={onClose}>
           <Pressable
             style={styles.detailCard}
             onPress={(e) => e.stopPropagation()}
@@ -1371,8 +1370,8 @@ export function ScheduleDetailModal({
               </ScrollView>
             )}
           </Pressable>
-        </KeyboardAvoidingView>
-      </Pressable>
+        </Pressable>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }

--- a/components/time_picker_modal.tsx
+++ b/components/time_picker_modal.tsx
@@ -2,9 +2,12 @@
 import { ThemedText } from "@/components/themed-text";
 import React, { useEffect, useState } from "react";
 import {
+  Keyboard,
   Modal,
+  Platform,
   Pressable,
   StyleSheet,
+  TextInput,
   TouchableOpacity,
   View,
 } from "react-native";
@@ -90,7 +93,84 @@ function StepperPicker({
     </View>
   );
 }
+function HourStepperPicker({
+  label,
+  value,
+  onIncrease,
+  onDecrease,
+  onChange,
+}: {
+  label: string;
+  value: string;
+  onIncrease: () => void;
+  onDecrease: () => void;
+  onChange: (v: string) => void;
+}) {
+  const [inputValue, setInputValue] = useState(value);
+  const [isFocused, setIsFocused] = useState(false);
 
+  useEffect(() => {
+    if (!isFocused) {
+      setInputValue(value);
+    }
+  }, [value, isFocused]);
+
+  const handleChangeText = (text: string) => {
+    const cleaned = text.replace(/[^0-9]/g, "").slice(0, 2);
+    setInputValue(cleaned);
+
+    if (Platform.OS === "android" && cleaned.length === 2) {
+      const num = parseInt(cleaned, 10);
+      const clamped = Math.min(23, Math.max(0, num));
+      const padded = padTwo(clamped);
+      setInputValue(padded);
+      onChange(padded);
+      Keyboard.dismiss();
+    }
+  };
+
+  const handleBlur = () => {
+    setIsFocused(false);
+    const num = parseInt(inputValue, 10);
+    if (isNaN(num) || inputValue === "") {
+      setInputValue(value); // 원래 값 복원
+      return;
+    }
+    const clamped = Math.min(23, Math.max(0, num));
+    const padded = padTwo(clamped);
+    setInputValue(padded);
+    onChange(padded);
+  };
+
+  return (
+    <View style={styles.stepperBox}>
+      <ThemedText style={styles.stepperLabel}>{label}</ThemedText>
+      <View style={styles.stepperRow}>
+        <TouchableOpacity style={styles.stepperButton} onPress={onDecrease}>
+          <ThemedText style={styles.stepperButtonText}>-</ThemedText>
+        </TouchableOpacity>
+
+        <TextInput
+          style={styles.stepperValueInput}
+          value={inputValue}
+          onChangeText={handleChangeText}
+          onFocus={() => {
+            setIsFocused(true);
+            setInputValue("");
+          }}
+          onBlur={handleBlur}
+          keyboardType="number-pad"
+          maxLength={2}
+          returnKeyType="done"
+        />
+
+        <TouchableOpacity style={styles.stepperButton} onPress={onIncrease}>
+          <ThemedText style={styles.stepperButtonText}>+</ThemedText>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}
 const TimePickerModal = ({
   visible,
   startHour,
@@ -158,11 +238,12 @@ const TimePickerModal = ({
           <View style={styles.section}>
             <ThemedText style={styles.sectionTitle}>시작 시간</ThemedText>
             <View style={styles.pickerRow}>
-              <StepperPicker
+              <HourStepperPicker
                 label="시"
                 value={tempStartHour}
                 onIncrease={() => setTempStartHour(getNextHour(tempStartHour))}
                 onDecrease={() => setTempStartHour(getPrevHour(tempStartHour))}
+                onChange={setTempStartHour}
               />
               <StepperPicker
                 label="분"
@@ -180,11 +261,12 @@ const TimePickerModal = ({
           <View style={styles.section}>
             <ThemedText style={styles.sectionTitle}>종료 시간</ThemedText>
             <View style={styles.pickerRow}>
-              <StepperPicker
+              <HourStepperPicker
                 label="시"
                 value={tempEndHour}
                 onIncrease={() => setTempEndHour(getNextHour(tempEndHour))}
                 onDecrease={() => setTempEndHour(getPrevHour(tempEndHour))}
+                onChange={setTempEndHour}
               />
               <StepperPicker
                 label="분"
@@ -355,5 +437,17 @@ const styles = StyleSheet.create({
     color: "#FFFFFF",
     fontSize: 14,
     fontWeight: "800",
+  },
+  stepperValueInput: {
+    flex: 2,
+    height: 40,
+    borderRadius: 12,
+    alignItems: "center",
+    justifyContent: "center",
+    marginVertical: 6,
+    fontSize: 18,
+    fontWeight: "800",
+    color: "#2A3C6B",
+    textAlign: "center",
   },
 });


### PR DESCRIPTION
## 관련 이슈

- Closes #64 

---

## 작업 내용

app/modal.tsx

- repeatType 초기값 "NONE" → "DAILY" 변경
- 카테고리 직접 추가 UI/로직 제거
- 색상 선택 섹션 제거
- TextInput autoFocus prop 제거
- 모달 닫힐 때 작성 중 내용 AsyncStorage에 draft 저장
- 모달 열릴 때 draft 복원 (AI 추천 params 존재 시 복원 스킵)

components/time_picker_modal.tsx

- StepperPicker에서 HourStepperPicker 분리
- HourStepperPicker에 TextInput 직접 입력 기능 추가
- returnKeyType="done" 으로 키보드 완료 처리
- Android 대응: 2자리 입력 완성 시 자동 확정 + 키보드 닫기

components/schedule_detail_modal.tsx

- 확인 버튼이 모달 카드 밖으로 밀려나던 레이아웃 버그 수정


---

## 테스트 체크리스트

- [x] 모달 최초 진입 시 반복 설정이 "매일"로 표시되는지
- [x] 저장 시 반복 타입이 DAILY로 전송되는지
- [x] 카테고리 추가, 색상 선택 UI가 노출되지 않는지
- [x] 모달 열릴 때 키보드가 자동으로 올라오지 않는지
- [x] 제목 입력 후 모달 닫고 재진입 시 내용 복원되는지
- [x] 시 영역 탭 시 기존 값이 지워지고 입력 가능한지
- [x] 확인 버튼이 모달 카드 안에 정상 위치하는지


---

## 참고사항

-
