### PR TITLE
fix: 토큰 무효화(401) 시 각 호출부 catch에서 에러 로그 출력되는 문제 수정

### DIFF
--- a/app/(tabs)/category.tsx
+++ b/app/(tabs)/category.tsx
@@ -316,6 +316,11 @@ export default function CategoryScreen() {
       setServerCategoryList(fetchedCategories);
     } catch (error) {
       if ((error as any)?.name === "NoTokenError") return;
+      if (
+        (error as any)?.response?.status === 401 ||
+        (error as any)?.response?.status === 403
+      )
+        return;
       console.error("카테고리 데이터 불러오기 실패", error);
     } finally {
       setIsLoading(false);

--- a/app/(tabs)/data.tsx
+++ b/app/(tabs)/data.tsx
@@ -408,6 +408,11 @@ export default function DataScreen() {
       }
     } catch (error) {
       if ((error as any)?.name === "NoTokenError") return;
+      if (
+        (error as any)?.response?.status === 401 ||
+        (error as any)?.response?.status === 403
+      )
+        return;
       console.error("히트맵 데이터 불러오기 실패", error);
       setHeatmapData([]);
     } finally {

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -155,8 +155,10 @@ export default function HomeScreen() {
     try {
       const routines = await RoutineService.getAll(currentDateString);
       setStoredRoutines(routines);
-    } catch (error) {
-      if ((error as any)?.name === "NoTokenError") return;
+    } catch (error: any) {
+      if (error?.name === "NoTokenError") return;
+      if (error?.response?.status === 401 || error?.response?.status === 403)
+        return;
       console.error("루틴 불러오기 실패", error);
       setStoredRoutines([]);
     }

--- a/components/schedule_content.tsx
+++ b/components/schedule_content.tsx
@@ -173,6 +173,11 @@ export default function ScheduleContent() {
       setNoTimeRoutines(noTimed);
     } catch (error) {
       if ((error as any)?.name === "NoTokenError") return;
+      if (
+        (error as any)?.response?.status === 401 ||
+        (error as any)?.response?.status === 403
+      )
+        return;
       console.error("루틴 불러오기 실패", error);
       setTimedRoutines([]);
       setNoTimeRoutines([]);


### PR DESCRIPTION
## 관련 이슈

- Closes #69 

---

## 작업 내용

 api_client.ts는 이미 401 수신 시 토큰 삭제 + authStore.setLoggedIn(false) + 로그인 화면 이동까지 처리하고 있었지만, 각 호출부 catch에서 401을 별도로 처리하지 않아 불필요한 에러 로그가 출력되는 문제가 있었음.

- index.tsx — loadStoredRoutines catch에 401/403 조건 추가
- category.tsx — refreshData catch에 401/403 조건 추가
- data.tsx — loadHeatmap catch에 401/403 조건 추가
- schedule_content.tsx — loadRoutines catch에 401/403 조건 추가

---

## 테스트 체크리스트



---

## 참고사항

-
