### PR TITLE
feat: 카테고리 화면 및 루틴 모달 UX 개선

### DIFF
--- a/app/(tabs)/category.tsx
+++ b/app/(tabs)/category.tsx
@@ -2,8 +2,6 @@
 import { DraggableCategoryList } from "@/components/DraggableCategoryList";
 import { Header } from "@/components/ui/_header";
 import {
-  DEFAULT_CATEGORIES,
-  EVENT_TYPES,
   getCategoryBadgeStyle,
   normalizeCategoryName,
   normalizeHexColor,
@@ -17,8 +15,9 @@ import { RoutineService } from "@/services/routine_service";
 import { authStore } from "@/store/authStore";
 import type { ScheduleRoutine } from "@/types/routine";
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import { useFocusEffect } from "expo-router";
+import { useFocusEffect, useRouter } from "expo-router";
 import React, { useCallback, useMemo, useRef, useState } from "react";
+
 import {
   ActivityIndicator,
   Alert,
@@ -67,7 +66,6 @@ interface CategorySummary {
   totalCount: number;
   completedCount: number;
   isCompletedCategory: boolean;
-  isFixedCategory: boolean;
 }
 // 카테고리 숨김/수정 상태를 저장하는 AsyncStorage 키
 const CATEGORY_META_STORAGE_KEY = "category_meta_v1";
@@ -84,10 +82,6 @@ const DEFAULT_USER_COLOR_PALETTE = [
   "#A8CD9B",
   "#C4C6D0",
 ];
-// 기본 카테고리인지 확인
-const isFixedCategoryName = (categoryName: string) => {
-  return Object.prototype.hasOwnProperty.call(EVENT_TYPES, categoryName);
-};
 // 오늘 날짜를 YYYY-MM-DD 형식으로 반환
 const getTodayString = () => {
   const today = new Date();
@@ -105,39 +99,49 @@ const isPastEndDate = (endDate?: string | null) => {
   return endDate < getTodayString();
 };
 // 루틴이 완료 상태인지 판단
-const isRoutineCompleted = (routine: ScheduleRoutine): boolean => {
-  // 종료일이 지났으면 완료로 처리
-  if (isPastEndDate(routine.endDate)) return true;
+const normalizeDate = (date?: string | null) => {
+  return date ? date.split("T")[0] : "";
+};
 
-  // state가 false이면 수동 완료로 처리
-  if (routine.state === false) return true;
+// 루틴이 완료 상태인지 판단
+const isRoutineCompleted = (routine: ScheduleRoutine): boolean => {
+  const startDate = normalizeDate(routine.startDate);
+  const endDate = normalizeDate(routine.endDate);
+
+  // 1. 기간이 끝난 루틴은 완료 처리
+  if (isPastEndDate(endDate)) return true;
 
   const completedDates = routine.completedDates ?? [];
-  if (completedDates.length === 0) return false;
+  const normalizedCompletedDates = completedDates.map(normalizeDate);
 
-  // 단일 날짜 루틴은 해당 날짜가 완료 목록에 있는지 확인
-  if (routine.startDate === routine.endDate) {
-    return completedDates.includes(routine.startDate);
+  // 2. 오늘 시작해서 오늘 끝나는 단일 날짜 루틴
+  if (startDate === endDate) {
+    return (
+      normalizedCompletedDates.includes(startDate) || routine.state === true
+    );
   }
 
-  // 반복/기간 루틴은 시작일부터 오늘 또는 종료일까지의 발생 날짜를 계산
   const today = getTodayString();
-  const effectiveEnd =
-    routine.endDate && routine.endDate <= today ? routine.endDate : today;
+  const effectiveEnd = endDate || today;
 
   const allDates = getRoutineOccurrenceDates(
-    routine,
-    routine.startDate,
+    {
+      ...routine,
+      startDate,
+      endDate,
+    },
+    startDate,
     effectiveEnd,
   );
 
-  const normalizedCompletedDates = completedDates.map(
-    (date) => date.split("T")[0],
-  );
+  // 3. 반복 날짜가 없으면 state 기준으로라도 완료 판단
+  if (allDates.length === 0) {
+    return routine.state === true;
+  }
 
-  return (
-    allDates.length > 0 &&
-    allDates.every((date) => normalizedCompletedDates.includes(date))
+  // 4. 기간 안의 모든 반복 날짜가 완료됐으면 완료 처리
+  return allDates.every((date) =>
+    normalizedCompletedDates.includes(normalizeDate(date)),
   );
 };
 
@@ -187,7 +191,7 @@ const saveCategoryMetas = async (metas: CategoryMeta[]) => {
     console.error("카테고리 메타 저장 실패", error);
   }
 };
-//서버 카테고리만 기준으로
+//서버에서 받아온 카테고리 목록을 기준으로 루틴 집계 및 정렬된 CategorySummary 배열을 반환
 const buildCategorySummaries = (
   routines: ScheduleRoutine[],
   metas: CategoryMeta[],
@@ -210,7 +214,6 @@ const buildCategorySummaries = (
       totalCount: 0,
       completedCount: 0,
       isCompletedCategory: false,
-      isFixedCategory: isFixedCategoryName(sc.name),
     });
   });
 
@@ -250,6 +253,7 @@ const buildCategorySummaries = (
     });
 };
 export default function CategoryScreen() {
+  const router = useRouter();
   const [selectedTab, setSelectedTab] = useState<CategoryTab>("ACTIVE");
   const [routines, setRoutines] = useState<ScheduleRoutine[]>([]);
   const [serverSortOrderMap, setServerSortOrderMap] = useState<
@@ -294,14 +298,10 @@ export default function CategoryScreen() {
         CategoryService.getAllIncludingHidden(),
       ]);
 
-      const serverCustomCategories: CustomCategory[] = fetchedCategories
-        .filter((c) => !DEFAULT_CATEGORIES.includes(c.name as any))
-        .map((c) => ({ name: c.name, color: c.colorCode }));
-
+      const serverCustomCategories: CustomCategory[] = fetchedCategories.map(
+        (c) => ({ name: c.name, color: c.colorCode }),
+      );
       const idMap: Record<string, number> = {};
-      fetchedCategories.forEach((c) => {
-        idMap[c.name] = c.id;
-      });
       const sortOrderMap: Record<number, number> = {};
       fetchedCategories.forEach((c) => {
         idMap[c.name] = c.id;
@@ -464,13 +464,6 @@ export default function CategoryScreen() {
     await saveCategoryMetas(next);
   };
 
-  const handleSelectFixedCategory = (categoryName: string) => {
-    const fixedStyle = EVENT_TYPES[categoryName as keyof typeof EVENT_TYPES];
-    setCategoryNameInput(categoryName);
-    setSelectedColor(fixedStyle.dot);
-    setPickerColor(fixedStyle.dot);
-  };
-
   const handleSavePickedColor = async () => {
     const normalizedColor = normalizeHexColor(pickerColor);
     const isHexColor = /^#([0-9A-F]{6}|[0-9A-F]{3})$/i.test(normalizedColor);
@@ -528,7 +521,7 @@ export default function CategoryScreen() {
     }
   };
 
-  // 카테고리 삭제 (서버 + 메타)
+  // 모달 내 카테고리 뱃지에서 직접 삭제할 때 호출 (서버 + 로컬 메타 삭제)
   const handleDeleteCustomCategory = async (category: CategorySummary) => {
     try {
       setIsLoading(true);
@@ -563,7 +556,7 @@ export default function CategoryScreen() {
 
       await refreshData();
     } catch (error) {
-      console.error("사용자 카테고리 삭제 실패", error);
+      console.error("카테고리 삭제 실패", error);
       Alert.alert(
         "카테고리 삭제 실패",
         "루틴 또는 카테고리를 삭제하지 못했어요.",
@@ -572,15 +565,14 @@ export default function CategoryScreen() {
       setIsLoading(false);
     }
   };
-
+  // 카테고리 뱃지 롱프레스 시 삭제 확인 Alert 표시
   const handleConfirmDeleteCustomCategory = (
     customCategory: CustomCategory,
   ) => {
     const matchedCategory = categories.find(
       (category) =>
-        !category.isFixedCategory &&
         category.name.trim().toLowerCase() ===
-          customCategory.name.trim().toLowerCase(),
+        customCategory.name.trim().toLowerCase(),
     );
 
     const categoryToDelete: CategorySummary = matchedCategory ?? {
@@ -593,7 +585,6 @@ export default function CategoryScreen() {
       totalCount: 0,
       completedCount: 0,
       isCompletedCategory: false,
-      isFixedCategory: false,
     };
 
     if (categoryToDelete.totalCount > 0) {
@@ -648,31 +639,29 @@ export default function CategoryScreen() {
       setIsSaving(true);
       const normalizedColor = normalizeHexColor(selectedColor);
 
-      if (!isFixedCategoryName(trimmedName)) {
-        if (!editingCategory) {
-          await CategoryService.create(trimmedName, normalizedColor);
+      if (!editingCategory) {
+        await CategoryService.create(trimmedName, normalizedColor);
+      } else {
+        let targetId = editingCategory.linkedCategoryId ?? null;
+
+        if (!targetId) {
+          const freshCategories = await CategoryService.getAll();
+          const matched = freshCategories.find(
+            (c) =>
+              c.name.trim().toLowerCase() ===
+              editingCategory.name.trim().toLowerCase(),
+          );
+          targetId = matched?.id ?? null;
+        }
+
+        if (targetId) {
+          await CategoryService.update(targetId, {
+            name: trimmedName,
+            colorCode: normalizedColor,
+            hidden: editingCategory.isHidden ?? false,
+          });
         } else {
-          let targetId = editingCategory.linkedCategoryId ?? null;
-
-          if (!targetId) {
-            const freshCategories = await CategoryService.getAll();
-            const matched = freshCategories.find(
-              (c) =>
-                c.name.trim().toLowerCase() ===
-                editingCategory.name.trim().toLowerCase(),
-            );
-            targetId = matched?.id ?? null;
-          }
-
-          if (targetId) {
-            await CategoryService.update(targetId, {
-              name: trimmedName,
-              colorCode: normalizedColor,
-              hidden: editingCategory.isHidden ?? false,
-            });
-          } else {
-            await CategoryService.create(trimmedName, normalizedColor);
-          }
+          await CategoryService.create(trimmedName, normalizedColor);
         }
       }
 
@@ -806,7 +795,7 @@ export default function CategoryScreen() {
           `루틴 ID ${routine.id} 삭제 중 서버 에러:`,
           error.response?.status,
         );
-        // 서버 에러가 나더라도 다음 루틴 삭제를 계속 시도하려면 skip, 아니면 throw
+        // 서버 에러가 발생해도 나머지 루틴 삭제를 계속 진행 (skip)
       }
     }
   };
@@ -825,14 +814,6 @@ export default function CategoryScreen() {
     return matched?.id ?? null;
   };
   const handleDeleteCategory = async (category: CategorySummary) => {
-    if (category.isFixedCategory) {
-      Alert.alert(
-        "삭제 불가",
-        `"${category.name}"은 기본 카테고리라 삭제할 수 없어요.`,
-      );
-      return;
-    }
-
     const hasRoutines = category.totalCount > 0;
 
     const message = hasRoutines
@@ -938,7 +919,7 @@ export default function CategoryScreen() {
   };
   // 카테고리 카드 한 개를 렌더링
   const renderCategoryItem = useCallback(
-    (item: CategorySummary, index: number) => {
+    (item: CategorySummary) => {
       const badgeText = selectedTab === "COMPLETED" ? "완료됨" : "진행중";
       const badgeStyle =
         selectedTab === "COMPLETED" ? styles.badgeCompleted : undefined;
@@ -947,11 +928,6 @@ export default function CategoryScreen() {
 
       return (
         <View style={styles.card}>
-          {/* 드래그 힌트 */}
-          <View style={styles.dragHandle}>
-            <Text style={styles.dragHandleText}>⠿</Text>
-          </View>
-
           <View style={styles.cardHeaderRow}>
             <View style={styles.cardTitleRow}>
               <View
@@ -970,16 +946,31 @@ export default function CategoryScreen() {
               </Text>
             </View>
           </View>
-
           <View style={styles.routineBox}>
-            {item.routines.length > 0 ? (
-              item.routines.slice(0, 3).map(renderRoutineItem)
-            ) : (
-              <Text style={styles.emptyRoutineText}>
-                {selectedTab === "ACTIVE"
-                  ? "연결된 루틴이 아직 없어요."
-                  : "완료된 루틴이 아직 없어요."}
-              </Text>
+            <View style={styles.routineContentBox}>
+              {item.routines.length > 0 ? (
+                item.routines.slice(0, 3).map(renderRoutineItem)
+              ) : (
+                <Text style={styles.emptyRoutineText}>
+                  {selectedTab === "ACTIVE"
+                    ? "연결된 루틴이 아직 없어요."
+                    : "완료된 루틴이 아직 없어요."}
+                </Text>
+              )}
+            </View>
+
+            {selectedTab === "ACTIVE" && (
+              <Pressable
+                style={styles.emptyRoutineAddButton}
+                onPress={() =>
+                  router.push({
+                    pathname: "/modal",
+                    params: { category: item.name },
+                  })
+                }
+              >
+                <Text style={styles.emptyRoutineAddButtonText}>+</Text>
+              </Pressable>
             )}
           </View>
 
@@ -1010,7 +1001,12 @@ export default function CategoryScreen() {
         </View>
       );
     },
-    [selectedTab],
+    [
+      selectedTab,
+      handleHideCategory,
+      handleDeleteCategory,
+      openEditCategoryModal,
+    ],
   );
 
   const renderHiddenCard = (item: CategorySummary) => {
@@ -1044,7 +1040,12 @@ export default function CategoryScreen() {
         </View>
 
         <View style={styles.mainCard}>
-          <View style={styles.headerArea} />
+          <View style={styles.headerArea}>
+            <Text style={styles.screenTitle}>카테고리</Text>
+            <Text style={styles.screenSubTitle}>
+              루틴을 카테고리별로 관리해보세요
+            </Text>
+          </View>
 
           <View style={styles.tabRow}>
             <View style={styles.tabWrapper}>
@@ -1082,15 +1083,13 @@ export default function CategoryScreen() {
                 </Text>
               </Pressable>
             </View>
-
-            <Pressable
-              style={styles.floatingAddButton}
-              onPress={openAddCategoryModal}
-            >
-              <Text style={styles.floatingAddButtonText}>+</Text>
-            </Pressable>
           </View>
-
+          <Pressable
+            style={styles.addCategoryButton}
+            onPress={openAddCategoryModal}
+          >
+            <Text style={styles.addCategoryButtonText}>+ 카테고리 추가</Text>
+          </Pressable>
           {isLoading ? (
             <View style={styles.loadingContainer}>
               <ActivityIndicator size="small" color="#405886" />
@@ -1150,19 +1149,20 @@ export default function CategoryScreen() {
         </View>
 
         {/* 카테고리 추가/수정 바텀시트 모달 */}
+        {/* 카테고리 추가/수정 바텀시트 모달 */}
         <Modal
           visible={isCategoryModalVisible}
           transparent
           animationType="fade"
         >
-          <Pressable
-            style={styles.modalBackdrop}
-            onPress={closeCategoryModal}
-          />
           <KeyboardAvoidingView
             style={styles.keyboardAvoidingView}
             behavior={Platform.OS === "ios" ? "padding" : undefined}
           >
+            <Pressable
+              style={styles.modalBackdrop}
+              onPress={closeCategoryModal}
+            />
             <Animated.View
               style={[
                 styles.modalContainer,
@@ -1190,59 +1190,10 @@ export default function CategoryScreen() {
                   onChangeText={setCategoryNameInput}
                   maxLength={20}
                 />
-                {!editingCategory && (
-                  <>
-                    <Text style={styles.inputLabel}>고정 카테고리</Text>
-                    <View style={styles.categoryGrid}>
-                      {DEFAULT_CATEGORIES.map((categoryName) => {
-                        const fixedStyle = EVENT_TYPES[categoryName];
-                        const badgeStyle = getCategoryBadgeStyle(
-                          categoryName,
-                          fixedStyle.dot,
-                        );
-                        const isSelected =
-                          categoryNameInput.trim() === categoryName;
 
-                        return (
-                          <Pressable
-                            key={categoryName}
-                            style={[
-                              styles.categoryBadge,
-                              {
-                                backgroundColor: badgeStyle.backgroundColor,
-                                borderColor: isSelected
-                                  ? badgeStyle.borderColor
-                                  : "transparent",
-                                borderWidth: isSelected ? 1.5 : 1,
-                              },
-                            ]}
-                            onPress={() =>
-                              handleSelectFixedCategory(categoryName)
-                            }
-                          >
-                            <View
-                              style={[
-                                styles.categoryBadgeDot,
-                                { backgroundColor: fixedStyle.dot },
-                              ]}
-                            />
-                            <Text
-                              style={[
-                                styles.categoryBadgeText,
-                                { color: badgeStyle.textColor },
-                              ]}
-                            >
-                              {categoryName}
-                            </Text>
-                          </Pressable>
-                        );
-                      })}
-                    </View>
-                  </>
-                )}
                 {!editingCategory && customCategories.length > 0 && (
                   <>
-                    <Text style={styles.inputLabel}>사용자 카테고리</Text>
+                    <Text style={styles.inputLabel}>카테고리</Text>
                     <View style={styles.categoryGrid}>
                       {customCategories.map((item) => {
                         const badgeStyle = getCategoryBadgeStyle(
@@ -1270,7 +1221,7 @@ export default function CategoryScreen() {
                               setSelectedColor(item.color);
                               setPickerColor(item.color);
                             }}
-                            //사용자 카테고리를 길게 누르면 삭제 확인창 표시
+                            // 카테고리를 길게 누르면 삭제 확인창 표시
                             onLongPress={() =>
                               handleConfirmDeleteCustomCategory(item)
                             }
@@ -1353,7 +1304,6 @@ export default function CategoryScreen() {
                       <Text style={styles.inlineColorPickerTitle}>
                         색상 선택
                       </Text>
-
                       <Pressable onPress={handleSavePickedColor}>
                         <Text style={styles.inlineColorPickerSaveText}>
                           저장
@@ -1363,9 +1313,7 @@ export default function CategoryScreen() {
 
                     <ColorPicker
                       value={pickerColor}
-                      onCompleteJS={(color) => {
-                        setPickerColor(color.hex);
-                      }}
+                      onCompleteJS={(color) => setPickerColor(color.hex)}
                       style={styles.colorPicker}
                     >
                       <Preview hideInitialColor style={styles.colorPreview} />
@@ -1443,10 +1391,6 @@ const styles = StyleSheet.create({
     borderColor: "#EEF1F6",
   },
 
-  headerArea: {
-    height: 10,
-  },
-
   tabRow: {
     flexDirection: "row",
     alignItems: "center",
@@ -1485,28 +1429,6 @@ const styles = StyleSheet.create({
   },
   tabTextActive: {
     color: "#233255",
-  },
-
-  floatingAddButton: {
-    width: 42,
-    height: 42,
-    borderRadius: 21,
-    backgroundColor: "#233255",
-    alignItems: "center",
-    justifyContent: "center",
-    shadowColor: "#233255",
-    shadowOpacity: 0.14,
-    shadowRadius: 10,
-    shadowOffset: { width: 0, height: 4 },
-    elevation: 3,
-  },
-  floatingAddButtonText: {
-    color: "#FFFFFF",
-    fontSize: 24,
-    fontWeight: "600",
-    lineHeight: 26,
-    marginTop: -1,
-    includeFontPadding: false,
   },
 
   loadingContainer: {
@@ -1592,13 +1514,18 @@ const styles = StyleSheet.create({
   badgeTextCompleted: {
     color: "#4C7A53",
   },
-
+  routineContentBox: {
+    flex: 1,
+  },
   routineBox: {
     backgroundColor: "#F8F9FB",
     borderRadius: 16,
     paddingHorizontal: 12,
     paddingVertical: 10,
     marginBottom: 14,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
   },
   routineItem: {
     flexDirection: "row",
@@ -1784,8 +1711,9 @@ const styles = StyleSheet.create({
     backgroundColor: "#FFFFFF",
     borderTopLeftRadius: 24,
     borderTopRightRadius: 24,
+    paddingBottom: 100,
+    marginBottom: -100,
   },
-
   modalContent: {
     padding: 20,
     paddingBottom: 32,
@@ -1993,16 +1921,42 @@ const styles = StyleSheet.create({
     flex: 1,
     justifyContent: "flex-end",
   },
-  dragHandle: {
-    position: "absolute",
-    top: 16,
-    right: 16,
-    padding: 4,
-    zIndex: 1,
+
+  headerArea: { marginBottom: 10, paddingHorizontal: 25, paddingTop: 25 },
+  screenTitle: {
+    fontSize: 24,
+    fontWeight: "800",
+    color: "#2A3C6B",
+    marginBottom: 6,
   },
-  dragHandleText: {
+  screenSubTitle: { fontSize: 13, color: "#A0B0D0", fontWeight: "500" },
+  addCategoryButton: {
+    marginHorizontal: 16,
+    marginBottom: 12,
+    paddingVertical: 12,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: "#F8F9FB",
+    alignItems: "center",
+    backgroundColor: "#F8F9FB",
+  },
+  addCategoryButtonText: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: "#405886",
+  },
+
+  emptyRoutineAddButton: {
+    width: 28,
+    height: 28,
+
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  emptyRoutineAddButtonText: {
     fontSize: 18,
-    color: "#C4C6D0",
-    letterSpacing: 1,
+    fontWeight: "700",
+    color: "#405886",
+    lineHeight: 20,
   },
 });

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,7 +1,7 @@
 import ScheduleContent from "@/components/schedule_content";
 import { Header } from "@/components/ui/_header";
 import AppCalendar from "@/components/ui/app_calendar";
-import { EVENT_TYPES } from "@/lib/category";
+
 import { RoutineService } from "@/services/routine_service";
 import { authStore } from "@/store/authStore";
 import type { MarkedDates } from "@/types/calendar";
@@ -83,14 +83,7 @@ function buildTimetableEvents(routines: ScheduleRoutine[]): TimetableEvent[] {
   });
   return events.sort((a, b) => a.startMinute - b.startMinute);
 }
-// 카테고리명에 맞는 색상 스타일 반환
 function getEventStyle(type: string, color?: string) {
-  const fixedStyle = EVENT_TYPES[type as keyof typeof EVENT_TYPES];
-
-  if (fixedStyle) {
-    return fixedStyle;
-  }
-
   const fallbackColor = color || "#9FA2D6";
 
   return {
@@ -223,15 +216,6 @@ export default function HomeScreen() {
         });
       }
     });
-    // 일정이 없을 때는 기본 카테고리 범례 표시
-    if (uniqueMap.size === 0) {
-      Object.keys(EVENT_TYPES).forEach((key) => {
-        uniqueMap.set(key, {
-          label: key,
-          dot: EVENT_TYPES[key as keyof typeof EVENT_TYPES].dot,
-        });
-      });
-    }
 
     return Array.from(uniqueMap.values());
   }, [timetableEvents]);

--- a/app/modal.tsx
+++ b/app/modal.tsx
@@ -5,7 +5,7 @@ import TimePickerModal from "@/components/time_picker_modal";
 import AppCalendar from "@/components/ui/app_calendar";
 import { IconSymbol } from "@/components/ui/icon-symbol";
 import { useRoutineForm } from "@/hooks/use_routine_form";
-import { EVENT_TYPES, type CustomCategory } from "@/lib/category";
+import { type CustomCategory } from "@/lib/category";
 import { CategoryService } from "@/services/category_service";
 import type {
   NotifyOption,
@@ -27,6 +27,7 @@ import {
   ScrollView,
   StyleSheet,
   Switch,
+  Text,
   TextInput,
   TouchableOpacity,
   View,
@@ -153,11 +154,6 @@ const REPEAT_EVERY_OPTIONS = Array.from({ length: 30 }, (_, i) =>
   String(i + 1),
 );
 
-//기본 카테고리인지 확인
-function isFixedCategory(categoryName: string) {
-  return Object.prototype.hasOwnProperty.call(EVENT_TYPES, categoryName);
-}
-
 //반복 단위 선택 컬럼
 function UnitOptionColumn({
   title,
@@ -266,8 +262,8 @@ export default function ModalScreen() {
   }>();
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [showTimeModal, setShowTimeModal] = useState(false);
-  const [showRepeatModal, setShowRepeatModal] = useState(false);
-  const [showCustomRepeatModal, setShowCustomRepeatModal] = useState(false);
+  const [showRepeatPanel, setShowRepeatPanel] = useState(false);
+  const [showCustomRepeatPanel, setShowCustomRepeatPanel] = useState(false);
   const [customCategories, setCustomCategories] = useState<CustomCategory[]>(
     [],
   );
@@ -309,11 +305,6 @@ export default function ModalScreen() {
     if (params.title) setTitle(params.title);
     if (params.category) {
       setCategory(params.category);
-      // 고정 카테고리면 색상도 같이 설정
-      if (isFixedCategory(params.category)) {
-        const style = EVENT_TYPES[params.category as keyof typeof EVENT_TYPES];
-        if (style) setSelectedColor(style.dot);
-      }
     }
     if (params.startTime) {
       const [h, m] = params.startTime.split(":");
@@ -440,12 +431,15 @@ export default function ModalScreen() {
   useEffect(() => {
     CategoryService.getAll()
       .then((serverCategories) => {
-        const custom = serverCategories
-          .filter((c) => !Object.keys(EVENT_TYPES).includes(c.name))
-          .map((c) => ({ name: c.name, color: c.colorCode }));
-        setCustomCategories(custom);
+        const categories = serverCategories.map((c) => ({
+          name: c.name,
+          color: c.colorCode,
+        }));
+        setCustomCategories(categories);
       })
       .catch((error) => {
+        const status = error?.response?.status;
+        if (status === 401 || status === 403) return;
         console.error("카테고리 불러오기 실패", error);
         setCustomCategories([]);
       });
@@ -529,15 +523,15 @@ export default function ModalScreen() {
   //반복 옵션 선택
   const handleSelectRepeatType = (option: RepeatType) => {
     if (option === "CUSTOM") {
-      setShowRepeatModal(false);
-      setShowCustomRepeatModal(true);
+      setShowRepeatPanel(false);
+      setShowCustomRepeatPanel(true);
       return;
     }
     setRepeatType(option);
     setRepeatInterval("1");
     setRepeatUnit("DAY");
     setRepeatDays([]);
-    setShowRepeatModal(false);
+    setShowRepeatPanel(false);
   };
 
   const handleSelectQuickWeeklyRepeat = (interval: "1" | "2") => {
@@ -545,7 +539,7 @@ export default function ModalScreen() {
     setRepeatInterval(interval);
     setRepeatUnit("WEEK");
     setRepeatDays([getWeekdayValueFromDate(startDate)]);
-    setShowRepeatModal(false);
+    setShowRepeatPanel(false);
   };
 
   // 사용자 설정 반복 단위는 일/주만 사용하고, 주 단위는 1주/2주까지만 허용
@@ -581,7 +575,7 @@ export default function ModalScreen() {
     }
 
     setRepeatType("CUSTOM");
-    setShowCustomRepeatModal(false);
+    setShowCustomRepeatPanel(false);
   };
 
   //시작/종료 시간 검증
@@ -943,32 +937,268 @@ export default function ModalScreen() {
 
               <View
                 style={[
-                  styles.rowBetween,
+                  styles.repeatSection,
                   isTimed ? styles.innerOptionRow : styles.repeatRowOnly,
                 ]}
               >
-                <View style={styles.iconLabel}>
-                  <IconSymbol name="repeat" size={18} color="#9FA2D6" />
-                  <ThemedText style={styles.optionLabel}>반복</ThemedText>
-                </View>
-
-                <TouchableOpacity
-                  style={[
-                    styles.valueButton,
-                    repeatType === "NONE" && styles.requiredValueButton,
-                  ]}
-                  onPress={() => setShowRepeatModal(true)}
-                >
-                  <ThemedText
-                    style={[
-                      styles.valueButtonText,
-                      repeatType === "NONE" && styles.requiredValueText,
-                    ]}
+                <View style={styles.repeatHeaderRow}>
+                  <View style={styles.iconLabel}>
+                    <IconSymbol name="repeat" size={18} color="#9FA2D6" />
+                    <ThemedText style={styles.optionLabel}>반복</ThemedText>
+                  </View>
+                  <TouchableOpacity
+                    style={styles.repeatOptionButton}
+                    onPress={() => {
+                      setShowRepeatPanel((prev) => !prev);
+                      setShowCustomRepeatPanel(false);
+                    }}
                   >
-                    {repeatLabel}
-                  </ThemedText>
-                  <IconSymbol name="chevron.right" size={14} color="#A0B0D0" />
-                </TouchableOpacity>
+                    <ThemedText style={styles.repeatOptionText}>
+                      {repeatLabel}
+                    </ThemedText>
+                  </TouchableOpacity>
+                </View>
+                {showRepeatPanel && (
+                  <View style={styles.repeatPanel}>
+                    {[
+                      { label: "매일", value: "DAILY" as RepeatType },
+                      {
+                        label: `매주(${getQuickWeekdayLabel(startDate)})`,
+                        value: "QUICK_WEEKLY",
+                      },
+                      {
+                        label: `격주(${getQuickWeekdayLabel(startDate)})`,
+                        value: "QUICK_BIWEEKLY",
+                      },
+                      { label: "사용자 설정", value: "CUSTOM" as RepeatType },
+                    ].map((item) => {
+                      const isQuickWeekly = item.value === "QUICK_WEEKLY";
+                      const isQuickBiweekly = item.value === "QUICK_BIWEEKLY";
+
+                      const isSelected =
+                        (repeatType === "DAILY" && item.value === "DAILY") ||
+                        (repeatType === "CUSTOM" &&
+                          repeatUnit === "WEEK" &&
+                          repeatInterval === "1" &&
+                          isQuickWeekly) ||
+                        (repeatType === "CUSTOM" &&
+                          repeatUnit === "WEEK" &&
+                          repeatInterval === "2" &&
+                          isQuickBiweekly) ||
+                        (repeatType === "CUSTOM" &&
+                          !(
+                            repeatUnit === "WEEK" &&
+                            (repeatInterval === "1" || repeatInterval === "2")
+                          ) &&
+                          item.value === "CUSTOM");
+
+                      return (
+                        <TouchableOpacity
+                          key={item.value}
+                          style={[
+                            styles.repeatOptionButton,
+                            isSelected && styles.repeatOptionButtonSelected,
+                          ]}
+                          onPress={() => {
+                            if (isQuickWeekly) {
+                              handleSelectQuickWeeklyRepeat("1");
+                              return;
+                            }
+
+                            if (isQuickBiweekly) {
+                              handleSelectQuickWeeklyRepeat("2");
+                              return;
+                            }
+
+                            handleSelectRepeatType(item.value as RepeatType);
+                          }}
+                        >
+                          <ThemedText
+                            style={[
+                              styles.repeatOptionText,
+                              isSelected && styles.repeatOptionTextSelected,
+                            ]}
+                          >
+                            {item.label}
+                          </ThemedText>
+                        </TouchableOpacity>
+                      );
+                    })}
+                  </View>
+                )}
+                {showCustomRepeatPanel && (
+                  <View style={styles.customRepeatPanel}>
+                    <View>
+                      <ThemedText style={styles.dialLabel}>단위</ThemedText>
+
+                      <View style={styles.repeatTwoColumnRow}>
+                        {(["DAY", "WEEK"] as RepeatUnit[]).map((unit) => (
+                          <TouchableOpacity
+                            key={unit}
+                            style={[
+                              styles.repeatOptionButton,
+                              repeatUnit === unit &&
+                                styles.repeatOptionButtonSelected,
+                              styles.repeatFlexButton,
+                            ]}
+                            onPress={() => handleSelectCustomRepeatUnit(unit)}
+                          >
+                            <ThemedText
+                              style={[
+                                styles.repeatOptionText,
+                                repeatUnit === unit &&
+                                  styles.repeatOptionTextSelected,
+                              ]}
+                            >
+                              {unit === "DAY" ? "일" : "주"}
+                            </ThemedText>
+                          </TouchableOpacity>
+                        ))}
+                      </View>
+                    </View>
+
+                    <View>
+                      <ThemedText style={styles.dialLabel}>빈도</ThemedText>
+
+                      {repeatUnit === "WEEK" ? (
+                        <View style={styles.repeatTwoColumnRow}>
+                          {WEEK_REPEAT_EVERY_OPTIONS.map((opt) => (
+                            <TouchableOpacity
+                              key={opt}
+                              style={[
+                                styles.repeatOptionButton,
+                                repeatInterval === opt &&
+                                  styles.repeatOptionButtonSelected,
+                                styles.repeatFlexButton,
+                              ]}
+                              onPress={() => setRepeatInterval(opt)}
+                            >
+                              <ThemedText
+                                style={[
+                                  styles.repeatOptionText,
+                                  repeatInterval === opt &&
+                                    styles.repeatOptionTextSelected,
+                                ]}
+                              >
+                                {opt === "1" ? "매주" : "격주"}
+                              </ThemedText>
+                            </TouchableOpacity>
+                          ))}
+                        </View>
+                      ) : (
+                        <View style={styles.repeatIntervalStepper}>
+                          <TouchableOpacity
+                            style={styles.repeatStepperButton}
+                            onPress={() => {
+                              const current = Number(repeatInterval || "1");
+                              const next = Math.max(1, current - 1);
+                              setRepeatInterval(String(next));
+                            }}
+                          >
+                            <Text style={styles.repeatStepperButtonText}>
+                              -
+                            </Text>
+                          </TouchableOpacity>
+
+                          <View style={styles.repeatIntervalInputBox}>
+                            <TextInput
+                              style={styles.repeatIntervalInput}
+                              value={repeatInterval}
+                              onChangeText={(text) => {
+                                const onlyNumber = text.replace(/[^0-9]/g, "");
+
+                                if (onlyNumber === "") {
+                                  setRepeatInterval("");
+                                  return;
+                                }
+
+                                const safeValue = String(
+                                  Math.min(
+                                    999,
+                                    Math.max(1, Number(onlyNumber)),
+                                  ),
+                                );
+                                setRepeatInterval(safeValue);
+                              }}
+                              onBlur={() => {
+                                if (
+                                  !repeatInterval ||
+                                  Number(repeatInterval) < 1
+                                ) {
+                                  setRepeatInterval("1");
+                                }
+                              }}
+                              keyboardType="number-pad"
+                              returnKeyType="done"
+                              maxLength={3}
+                            />
+
+                            <Text style={styles.repeatIntervalSuffix}>
+                              일마다
+                            </Text>
+                          </View>
+
+                          <TouchableOpacity
+                            style={styles.repeatStepperButton}
+                            onPress={() => {
+                              const current = Number(repeatInterval || "1");
+                              const next = Math.min(999, current + 1);
+                              setRepeatInterval(String(next));
+                            }}
+                          >
+                            <Text style={styles.repeatStepperButtonText}>
+                              +
+                            </Text>
+                          </TouchableOpacity>
+                        </View>
+                      )}
+                    </View>
+
+                    {repeatUnit === "WEEK" && (
+                      <View>
+                        <ThemedText style={styles.dialLabel}>요일</ThemedText>
+
+                        <View style={styles.weekdayRow}>
+                          {WEEKDAY_OPTIONS.map((day) => {
+                            const isSelected = repeatDays.includes(day.value);
+
+                            return (
+                              <TouchableOpacity
+                                key={day.value}
+                                style={[
+                                  styles.weekdayChip,
+                                  isSelected && styles.weekdayChipSelected,
+                                ]}
+                                onPress={() => handleToggleWeekday(day.value)}
+                              >
+                                <ThemedText
+                                  style={[
+                                    styles.weekdayChipText,
+                                    isSelected &&
+                                      styles.weekdayChipTextSelected,
+                                  ]}
+                                >
+                                  {day.label}
+                                </ThemedText>
+                              </TouchableOpacity>
+                            );
+                          })}
+                        </View>
+                      </View>
+                    )}
+
+                    <View style={styles.customRepeatFooter}>
+                      <TouchableOpacity
+                        style={styles.customRepeatDoneButton}
+                        onPress={handleSaveCustomRepeat}
+                      >
+                        <ThemedText style={styles.customRepeatDoneText}>
+                          적용
+                        </ThemedText>
+                      </TouchableOpacity>
+                    </View>
+                  </View>
+                )}
               </View>
             </View>
             {/* 저장 버튼 */}
@@ -991,180 +1221,6 @@ export default function ModalScreen() {
         onClose={() => setShowTimeModal(false)}
         onApply={handleApplyTime}
       />
-
-      {/* 반복 옵션 선택 모달 */}
-      {showRepeatModal && (
-        <Pressable
-          style={styles.inlineModalOverlay}
-          onPress={() => setShowRepeatModal(false)}
-        >
-          <Pressable
-            style={styles.inlineModalCard}
-            onPress={(e) => e.stopPropagation()}
-          >
-            <View style={styles.inlineModalHeader}>
-              <ThemedText style={styles.inlineModalTitle}>반복 설정</ThemedText>
-
-              <TouchableOpacity onPress={() => setShowRepeatModal(false)}>
-                <ThemedText style={styles.inlineModalDone}>닫기</ThemedText>
-              </TouchableOpacity>
-            </View>
-
-            <View style={styles.optionList}>
-              {[
-                { label: "매일", value: "DAILY" as RepeatType },
-
-                {
-                  label: `매주(${getQuickWeekdayLabel(startDate)})`,
-                  value: "QUICK_WEEKLY",
-                },
-                {
-                  label: `격주(${getQuickWeekdayLabel(startDate)})`,
-                  value: "QUICK_BIWEEKLY",
-                },
-
-                { label: "사용자 설정", value: "CUSTOM" as RepeatType },
-              ].map((item) => {
-                const isQuickWeekly = item.value === "QUICK_WEEKLY";
-                const isQuickBiweekly = item.value === "QUICK_BIWEEKLY";
-                const isSelected =
-                  (repeatType === "DAILY" && item.value === "DAILY") ||
-                  (repeatType === "CUSTOM" &&
-                    repeatUnit === "WEEK" &&
-                    repeatInterval === "1" &&
-                    isQuickWeekly) ||
-                  (repeatType === "CUSTOM" &&
-                    repeatUnit === "WEEK" &&
-                    repeatInterval === "2" &&
-                    isQuickBiweekly) ||
-                  (repeatType === "CUSTOM" &&
-                    !(
-                      repeatUnit === "WEEK" &&
-                      (repeatInterval === "1" || repeatInterval === "2")
-                    ) &&
-                    item.value === "CUSTOM");
-
-                return (
-                  <TouchableOpacity
-                    key={item.value}
-                    style={styles.optionListItem}
-                    onPress={() => {
-                      if (isQuickWeekly) {
-                        handleSelectQuickWeeklyRepeat("1");
-                        return;
-                      }
-
-                      if (isQuickBiweekly) {
-                        handleSelectQuickWeeklyRepeat("2");
-                        return;
-                      }
-
-                      handleSelectRepeatType(item.value as RepeatType);
-                    }}
-                  >
-                    <ThemedText
-                      style={[
-                        styles.optionListItemText,
-                        isSelected && styles.optionListItemTextSelected,
-                      ]}
-                    >
-                      {item.label}
-                    </ThemedText>
-
-                    {isSelected && item.value !== "CUSTOM" && (
-                      <IconSymbol name="checkmark" size={16} color="#405886" />
-                    )}
-                  </TouchableOpacity>
-                );
-              })}
-            </View>
-          </Pressable>
-        </Pressable>
-      )}
-
-      {/* 사용자 설정 반복 모달 */}
-      {showCustomRepeatModal && (
-        <Pressable
-          style={styles.inlineModalOverlay}
-          onPress={() => setShowCustomRepeatModal(false)}
-        >
-          <Pressable
-            style={styles.inlineModalCard}
-            onPress={(e) => e.stopPropagation()}
-          >
-            <View style={styles.inlineModalHeader}>
-              <ThemedText style={styles.inlineModalTitle}>
-                사용자 설정 반복
-              </ThemedText>
-
-              <TouchableOpacity onPress={handleSaveCustomRepeat}>
-                <ThemedText style={styles.inlineModalDone}>완료</ThemedText>
-              </TouchableOpacity>
-            </View>
-
-            <View style={styles.inlinePickerRow}>
-              <NumberOptionColumn
-                title="빈도"
-                options={
-                  repeatUnit === "WEEK"
-                    ? WEEK_REPEAT_EVERY_OPTIONS
-                    : REPEAT_EVERY_OPTIONS
-                }
-                selectedValue={repeatInterval}
-                onSelect={setRepeatInterval}
-              />
-
-              <UnitOptionColumn
-                title="단위"
-                options={[
-                  { label: "일", value: "DAY" },
-                  { label: "주", value: "WEEK" },
-                ]}
-                selectedValue={repeatUnit}
-                onSelect={handleSelectCustomRepeatUnit}
-              />
-            </View>
-
-            {/* 주 단위일 때만 요일 선택 영역 표시 */}
-            {repeatUnit === "WEEK" && (
-              <View style={styles.weekdaySection}>
-                <View style={styles.weekdayTitleRow}>
-                  <ThemedText style={styles.weekdayTitle}>요일</ThemedText>
-                  <ThemedText style={styles.weekdayHelperText}>
-                    주 반복은 격주까지만 가능해요
-                  </ThemedText>
-                </View>
-
-                <View style={styles.weekdayGrid}>
-                  {WEEKDAY_OPTIONS.map((day) => {
-                    const isSelected = repeatDays.includes(day.value);
-
-                    return (
-                      <TouchableOpacity
-                        key={day.value}
-                        style={[
-                          styles.weekdayChip,
-                          isSelected && styles.weekdayChipSelected,
-                        ]}
-                        onPress={() => handleToggleWeekday(day.value)}
-                      >
-                        <ThemedText
-                          style={[
-                            styles.weekdayChipText,
-                            isSelected && styles.weekdayChipTextSelected,
-                          ]}
-                        >
-                          {day.label}
-                        </ThemedText>
-                      </TouchableOpacity>
-                    );
-                  })}
-                </View>
-              </View>
-            )}
-          </Pressable>
-        </Pressable>
-      )}
     </ThemedView>
   );
 }
@@ -1195,7 +1251,8 @@ const styles = StyleSheet.create({
     borderTopRightRadius: 32,
     paddingHorizontal: 24,
     paddingTop: 0,
-    paddingBottom: 0,
+    paddingBottom: 100,
+    marginBottom: -100,
     maxHeight: "92%",
     overflow: "hidden",
   },
@@ -1542,22 +1599,28 @@ const styles = StyleSheet.create({
     flexWrap: "wrap",
     gap: 8,
   },
+  weekdayRow: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    width: "100%",
+  },
 
   weekdayChip: {
-    width: "22%",
-    minHeight: 38,
-    borderRadius: 999,
+    width: 32,
+    height: 32,
+    borderRadius: 16,
     backgroundColor: "#F3F4F8",
     alignItems: "center",
     justifyContent: "center",
   },
 
   weekdayChipSelected: {
-    backgroundColor: "#6BBFCC",
+    borderColor: "#405886",
+    backgroundColor: "#405886",
   },
-
   weekdayChipText: {
-    fontSize: 13,
+    fontSize: 12,
     fontWeight: "800",
     color: "#8A8C9A",
   },
@@ -1588,5 +1651,196 @@ const styles = StyleSheet.create({
     color: "#7A87A6",
     marginBottom: 8,
     paddingHorizontal: 4,
+  },
+  repeatPanel: {
+    marginTop: 10,
+    gap: 6,
+  },
+
+  customRepeatPanel: {
+    marginTop: 12,
+    gap: 14,
+  },
+
+  dialLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: "#A0B0D0",
+    marginBottom: 8,
+  },
+
+  repeatOptionButton: {
+    borderWidth: 0.5,
+    borderColor: "#E4E7EE",
+    borderRadius: 11,
+    paddingVertical: 8,
+    paddingHorizontal: 10,
+    minHeight: 34,
+    backgroundColor: "#FAFBFD",
+  },
+
+  repeatOptionButtonSelected: {
+    borderColor: "#405886",
+    backgroundColor: "#F3F6FB",
+  },
+
+  repeatOptionText: {
+    fontSize: 14,
+    fontWeight: "600",
+    color: "#6D7690",
+  },
+
+  repeatOptionTextSelected: {
+    color: "#405886",
+  },
+
+  repeatTwoColumnRow: {
+    flexDirection: "row",
+    gap: 6,
+  },
+
+  repeatFlexButton: {
+    flex: 1,
+    alignItems: "center",
+  },
+
+  frequencyGrid: {
+    flexDirection: "row",
+    flexWrap: "wrap",
+    gap: 8,
+  },
+
+  frequencyChip: {
+    minWidth: 42,
+    paddingVertical: 9,
+    paddingHorizontal: 10,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: "#E4E7EE",
+    backgroundColor: "#FAFBFD",
+    alignItems: "center",
+  },
+
+  frequencyChipSelected: {
+    borderColor: "#405886",
+    backgroundColor: "#EEF2FF",
+  },
+
+  frequencyChipText: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: "#6D7690",
+  },
+
+  frequencyChipTextSelected: {
+    color: "#405886",
+  },
+  customRepeatFooter: {
+    flexDirection: "row",
+    justifyContent: "flex-end",
+    marginTop: -2,
+  },
+
+  customRepeatDoneButton: {
+    paddingVertical: 8,
+    paddingHorizontal: 14,
+    borderRadius: 999,
+    backgroundColor: "#EEF2FF",
+  },
+
+  customRepeatDoneText: {
+    fontSize: 13,
+    fontWeight: "800",
+    color: "#405886",
+  },
+
+  repeatSection: {
+    width: "100%",
+  },
+
+  repeatHeaderRow: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+
+  repeatSelectButton: {
+    minWidth: 96,
+    alignItems: "center",
+    borderWidth: 1,
+    borderColor: "#E4E7EE",
+    borderRadius: 14,
+    paddingVertical: 9,
+    paddingHorizontal: 12,
+    backgroundColor: "#FFFFFF",
+  },
+
+  repeatIntervalValueBox: {
+    flex: 1,
+    height: 42,
+    borderRadius: 14,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#FAFBFD",
+    borderWidth: 1,
+    borderColor: "#E4E7EE",
+  },
+
+  repeatIntervalValueText: {
+    fontSize: 14,
+    fontWeight: "800",
+    color: "#405886",
+  },
+  repeatIntervalStepper: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+
+  repeatStepperButton: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#F3F4F8",
+    borderWidth: 1,
+    borderColor: "#E4E7EE",
+  },
+
+  repeatStepperButtonText: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: "#405886",
+  },
+
+  repeatIntervalInputBox: {
+    flex: 1,
+    height: 34,
+    borderRadius: 17,
+    borderWidth: 1,
+    borderColor: "#E7EAF3",
+    backgroundColor: "#FAFBFD",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 10,
+  },
+  repeatIntervalInput: {
+    minWidth: 28,
+    maxWidth: 52,
+    paddingVertical: 0,
+    paddingHorizontal: 0,
+    fontSize: 14,
+    fontWeight: "700",
+    color: "#2F3550",
+    textAlign: "center",
+  },
+
+  repeatIntervalSuffix: {
+    marginLeft: 4,
+    fontSize: 13,
+    fontWeight: "700",
+    color: "#6D7690",
   },
 });

--- a/components/DraggableCategoryList.tsx
+++ b/components/DraggableCategoryList.tsx
@@ -25,6 +25,8 @@ interface Props<T extends DraggableItem> {
   contentContainerStyle?: any;
 }
 
+const SPRING_CONFIG = { damping: 20, stiffness: 100, mass: 0.6 };
+
 function DraggableRow<T extends DraggableItem>({
   item,
   index,
@@ -32,6 +34,7 @@ function DraggableRow<T extends DraggableItem>({
   hoverIndex,
   dragY,
   draggedHeight,
+  startAbsoluteY,
   onLayout,
   onDragStart,
   onDragUpdate,
@@ -44,6 +47,7 @@ function DraggableRow<T extends DraggableItem>({
   hoverIndex: number | null;
   dragY: SharedValue<number>;
   draggedHeight: number;
+  startAbsoluteY: SharedValue<number>;
   onLayout: (index: number, e: LayoutChangeEvent) => void;
   onDragStart: (index: number, absoluteY: number) => void;
   onDragUpdate: (absoluteY: number) => void;
@@ -62,6 +66,9 @@ function DraggableRow<T extends DraggableItem>({
         })
         .onUpdate((e) => {
           "worklet";
+          // dragY를 worklet에서 직접 업데이트 — JS 스레드 경유 없이 즉시 반영
+          dragY.value = e.absoluteY - startAbsoluteY.value;
+          // hover 인덱스 계산만 JS 스레드로
           runOnJS(onDragUpdate)(e.absoluteY);
         })
         .onEnd(() => {
@@ -72,7 +79,7 @@ function DraggableRow<T extends DraggableItem>({
           "worklet";
           runOnJS(onDragEnd)();
         }),
-    [index, onDragStart, onDragUpdate, onDragEnd],
+    [index, onDragStart, onDragUpdate, onDragEnd, dragY, startAbsoluteY],
   );
 
   const animatedStyle = useAnimatedStyle(() => {
@@ -88,9 +95,7 @@ function DraggableRow<T extends DraggableItem>({
 
     if (draggingIndex === null || hoverIndex === null) {
       return {
-        transform: [
-          { translateY: withSpring(0, { damping: 20, stiffness: 200 }) },
-        ],
+        transform: [{ translateY: withSpring(0, SPRING_CONFIG) }],
         zIndex: 1,
         opacity: 1,
       };
@@ -101,14 +106,7 @@ function DraggableRow<T extends DraggableItem>({
 
     if (from > to && index >= to && index < from) {
       return {
-        transform: [
-          {
-            translateY: withSpring(draggedHeight, {
-              damping: 20,
-              stiffness: 200,
-            }),
-          },
-        ],
+        transform: [{ translateY: withSpring(draggedHeight, SPRING_CONFIG) }],
         zIndex: 1,
         opacity: 1,
       };
@@ -116,23 +114,14 @@ function DraggableRow<T extends DraggableItem>({
 
     if (from < to && index > from && index <= to) {
       return {
-        transform: [
-          {
-            translateY: withSpring(-draggedHeight, {
-              damping: 20,
-              stiffness: 200,
-            }),
-          },
-        ],
+        transform: [{ translateY: withSpring(-draggedHeight, SPRING_CONFIG) }],
         zIndex: 1,
         opacity: 1,
       };
     }
 
     return {
-      transform: [
-        { translateY: withSpring(0, { damping: 20, stiffness: 200 }) },
-      ],
+      transform: [{ translateY: withSpring(0, SPRING_CONFIG) }],
       zIndex: 1,
       opacity: 1,
     };
@@ -172,23 +161,24 @@ export function DraggableCategoryList<T extends DraggableItem>({
   const itemsRef = useRef<T[]>(data);
   const draggingIndexRef = useRef<number | null>(null);
   const hoverIndexRef = useRef<number | null>(null);
-  const startAbsoluteYRef = useRef(0);
   const isEndedRef = useRef(false);
   const flatListRef = useRef<FlatList>(null);
-  const containerRef = useRef<View>(null); // ← View ref로 measure
+  const containerRef = useRef<View>(null);
   const autoScrollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const lastReorderTime = useRef<number>(0);
 
   const dragY = useSharedValue(0);
   const isDragging = useSharedValue(false);
+  const startAbsoluteY = useSharedValue(0);
 
   useEffect(() => {
     if (draggingIndex === null) {
-      // 드래그 종료 후 500ms 이내엔 외부 data 변경 무시
       if (Date.now() - lastReorderTime.current < 500) return;
       setItems([...data]);
       itemsRef.current = data;
     }
   }, [data, draggingIndex]);
+
   const stopAutoScroll = useCallback(() => {
     if (autoScrollTimer.current) {
       clearInterval(autoScrollTimer.current);
@@ -200,7 +190,7 @@ export function DraggableCategoryList<T extends DraggableItem>({
     (direction: "up" | "down") => {
       stopAutoScroll();
       autoScrollTimer.current = setInterval(() => {
-        scrollOffsetY.current += direction === "down" ? 8 : -8;
+        scrollOffsetY.current += direction === "down" ? 10 : -10;
         if (scrollOffsetY.current < 0) scrollOffsetY.current = 0;
         flatListRef.current?.scrollToOffset({
           offset: scrollOffsetY.current,
@@ -244,23 +234,28 @@ export function DraggableCategoryList<T extends DraggableItem>({
 
   const handleDragStart = useCallback(
     (index: number, absoluteY: number) => {
+      // 드래그 시작마다 재측정
+      containerRef.current?.measureInWindow((_x, y, _w, h) => {
+        listTopY.current = y;
+        listHeight.current = h;
+      });
+
       isEndedRef.current = false;
       draggingIndexRef.current = index;
       hoverIndexRef.current = index;
-      startAbsoluteYRef.current = absoluteY;
+      startAbsoluteY.value = absoluteY;
       dragY.value = 0;
       isDragging.value = true;
       setDraggedHeight(itemHeights.current[index] ?? 200);
       setDraggingIndex(index);
       setHoverIndex(index);
     },
-    [dragY, isDragging],
+    [dragY, isDragging, startAbsoluteY],
   );
 
   const handleDragUpdate = useCallback(
     (absoluteY: number) => {
-      dragY.value = absoluteY - startAbsoluteYRef.current;
-
+      // dragY는 이미 worklet에서 업데이트됨 — 여기선 hover 인덱스와 오토스크롤만 처리
       const listBottom = listTopY.current + listHeight.current;
       const scrollZone = 80;
       if (absoluteY > listBottom - scrollZone) {
@@ -277,9 +272,9 @@ export function DraggableCategoryList<T extends DraggableItem>({
         setHoverIndex(newHover);
       }
     },
-    [dragY, getIndexFromY, startAutoScroll, stopAutoScroll],
+    [getIndexFromY, startAutoScroll, stopAutoScroll],
   );
-  const lastReorderTime = useRef<number>(0);
+
   const handleDragEnd = useCallback(() => {
     if (isEndedRef.current) return;
     isEndedRef.current = true;
@@ -288,13 +283,9 @@ export function DraggableCategoryList<T extends DraggableItem>({
 
     const from = draggingIndexRef.current;
     const to = hoverIndexRef.current;
-    console.log("from:", from, "to:", to);
-    console.log(
-      "현재 내부 순서:",
-      itemsRef.current.map((item) => item.name),
-    );
+
     isDragging.value = false;
-    dragY.value = withSpring(0, { damping: 20, stiffness: 200 });
+    dragY.value = withSpring(0, { damping: 20, stiffness: 100, mass: 0.6 });
 
     if (from !== null && to !== null && from !== to) {
       const currentItems = [...itemsRef.current];
@@ -305,6 +296,7 @@ export function DraggableCategoryList<T extends DraggableItem>({
       setItems(currentItems);
       onReorder(currentItems);
     }
+
     setDraggingIndex(null);
     setHoverIndex(null);
     draggingIndexRef.current = null;
@@ -316,20 +308,11 @@ export function DraggableCategoryList<T extends DraggableItem>({
     <View
       ref={containerRef}
       style={style}
-      onLayout={(e) => {
-        listHeight.current = e.nativeEvent.layout.height;
-        containerRef.current?.measure(
-          (
-            _x: number,
-            _y: number,
-            _w: number,
-            _h: number,
-            _px: number,
-            py: number,
-          ) => {
-            listTopY.current = py;
-          },
-        );
+      onLayout={() => {
+        containerRef.current?.measureInWindow((_x, y, _w, h) => {
+          listTopY.current = y;
+          listHeight.current = h;
+        });
       }}
     >
       <FlatList
@@ -355,6 +338,7 @@ export function DraggableCategoryList<T extends DraggableItem>({
             hoverIndex={hoverIndex}
             dragY={dragY}
             draggedHeight={draggedHeight}
+            startAbsoluteY={startAbsoluteY}
             onLayout={onItemLayout}
             onDragStart={handleDragStart}
             onDragUpdate={handleDragUpdate}

--- a/components/schedule_detail_modal.tsx
+++ b/components/schedule_detail_modal.tsx
@@ -1,10 +1,6 @@
 //schedule_detail_modal.tsx
 import { IconSymbol } from "@/components/ui/icon-symbol";
-import {
-  EVENT_TYPES,
-  getCategoryChipStyle,
-  getCategoryStyle,
-} from "@/lib/category";
+import { getCategoryChipStyle, getCategoryStyle } from "@/lib/category";
 import { CategoryService } from "@/services/category_service";
 import { RoutineService } from "@/services/routine_service";
 import type {
@@ -17,7 +13,7 @@ import { Ionicons } from "@expo/vector-icons";
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import {
   Alert,
-  KeyboardAvoidingView,
+  Keyboard,
   Modal,
   Platform,
   Pressable,
@@ -249,12 +245,55 @@ function TimeStepperControl({
   value,
   onIncrease,
   onDecrease,
+  onChange,
 }: {
   label: string;
   value: string;
   onIncrease: () => void;
   onDecrease: () => void;
+  onChange?: (value: string) => void;
 }) {
+  const [inputValue, setInputValue] = useState(value);
+  const [isFocused, setIsFocused] = useState(false);
+
+  useEffect(() => {
+    if (!isFocused) {
+      setInputValue(value);
+    }
+  }, [value, isFocused]);
+
+  const handleChangeText = (text: string) => {
+    const cleaned = text.replace(/[^0-9]/g, "").slice(0, 2);
+    setInputValue(cleaned);
+
+    if (Platform.OS === "android" && cleaned.length === 2) {
+      const num = Number(cleaned);
+      const safeHour = padNumber(clamp(num, 0, 23));
+      setInputValue(safeHour);
+      onChange?.(safeHour);
+      Keyboard.dismiss();
+    }
+  };
+
+  const handleBlur = () => {
+    setIsFocused(false);
+
+    if (!onChange || inputValue === "") {
+      setInputValue(value);
+      return;
+    }
+
+    const num = Number(inputValue);
+    if (Number.isNaN(num)) {
+      setInputValue(value);
+      return;
+    }
+
+    const safeHour = padNumber(clamp(num, 0, 23));
+    setInputValue(safeHour);
+    onChange(safeHour);
+  };
+
   return (
     <View style={styles.timeStepperBox}>
       <Text style={styles.timeStepperLabel}>{label}</Text>
@@ -264,9 +303,29 @@ function TimeStepperControl({
           <Text style={styles.timeStepperButtonText}>-</Text>
         </TouchableOpacity>
 
-        <View style={styles.timeStepperValueBox}>
-          <Text style={styles.timeStepperValueText}>{value}</Text>
-        </View>
+        {onChange ? (
+          <TextInput
+            style={styles.timeStepperValueInput}
+            value={inputValue}
+            onChangeText={handleChangeText}
+            onFocus={() => {
+              setIsFocused(true);
+              setInputValue("");
+            }}
+            onBlur={handleBlur}
+            keyboardType="number-pad"
+            maxLength={2}
+            returnKeyType="done"
+            blurOnSubmit
+            onSubmitEditing={() => {
+              Keyboard.dismiss();
+            }}
+          />
+        ) : (
+          <View style={styles.timeStepperValueBox}>
+            <Text style={styles.timeStepperValueText}>{value}</Text>
+          </View>
+        )}
 
         <TouchableOpacity style={styles.timeStepperButton} onPress={onIncrease}>
           <Text style={styles.timeStepperButtonText}>+</Text>
@@ -275,7 +334,6 @@ function TimeStepperControl({
     </View>
   );
 }
-
 export function ScheduleDetailModal({
   visible,
   routine,
@@ -286,7 +344,7 @@ export function ScheduleDetailModal({
   const [isEditMode, setIsEditMode] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
   const [title, setTitle] = useState("");
-  const [categoryName, setCategoryName] = useState("기타");
+  const [categoryName, setCategoryName] = useState("");
   const [selectedColor, setSelectedColor] = useState("#C4C6D0");
 
   const [startDateYear, setStartDateYear] = useState("2026");
@@ -327,9 +385,8 @@ export function ScheduleDetailModal({
     setIsEditMode(false);
     setShowCalendar(false);
     setTitle(targetRoutine.title);
-    setCategoryName(targetRoutine.categoryName ?? "기타");
-    setSelectedColor(targetRoutine.color ?? EVENT_TYPES["기타"].dot);
-
+    setCategoryName(targetRoutine.categoryName ?? "");
+    setSelectedColor(targetRoutine.color ?? "#C4C6D0");
     setStartDateYear(startDateParts.year);
     setStartDateMonth(startDateParts.month);
     setStartDateDay(startDateParts.day);
@@ -354,12 +411,17 @@ export function ScheduleDetailModal({
 
     CategoryService.getAll()
       .then((serverCategories) => {
-        const custom = serverCategories
-          .filter((c) => !Object.keys(EVENT_TYPES).includes(c.name))
-          .map((c) => ({ name: c.name, color: c.colorCode }));
-        setCustomCategories(custom);
+        const categories = serverCategories.map((c) => ({
+          name: c.name,
+          color: c.colorCode,
+        }));
+        setCustomCategories(categories);
       })
-      .catch(console.error);
+      .catch((error) => {
+        const status = error?.response?.status;
+        if (status === 401 || status === 403) return;
+        console.error("카테고리 불러오기 실패", error);
+      });
   }, [visible]);
 
   useEffect(() => {
@@ -375,10 +437,7 @@ export function ScheduleDetailModal({
   }, [customCategories]);
 
   const categoryList = useMemo(() => {
-    return [
-      ...Object.keys(EVENT_TYPES),
-      ...customCategories.map((item) => item.name),
-    ];
+    return customCategories.map((item) => item.name);
   }, [customCategories]);
 
   const previewRoutine = useMemo(() => {
@@ -462,10 +521,6 @@ export function ScheduleDetailModal({
         style: "destructive",
         onPress: async () => {
           try {
-            // 서버 버그 우회:
-            // isCompleted: true 상태의 루틴은 삭제 시 500 에러 발생
-            // 삭제 전 오늘 날짜 기준으로 완료 상태를 확인하고
-            // true면 토글로 false로 되돌린 뒤 삭제
             const today = new Date();
             const todayString = [
               today.getFullYear(),
@@ -479,9 +534,7 @@ export function ScheduleDetailModal({
             if (isCompletedToday) {
               try {
                 await RoutineService.toggleComplete(routine.id, todayString);
-              } catch {
-                // 토글 실패 시 그냥 삭제 시도
-              }
+              } catch {}
             }
 
             await RoutineService.deleteById(routine.id);
@@ -600,27 +653,9 @@ export function ScheduleDetailModal({
           c.name.trim().toLowerCase() === categoryName.trim().toLowerCase(),
       );
       let resolvedCategoryId: number | null = matched?.id ?? null;
-
       if (resolvedCategoryId === null) {
-        try {
-          const created = await CategoryService.create(
-            categoryName,
-            selectedColor,
-          );
-          resolvedCategoryId = created.id;
-        } catch (createError: any) {
-          if (createError?.response?.status === 409) {
-            const retry = await CategoryService.getAll();
-            const retryMatched = retry.find(
-              (c) =>
-                c.name.trim().toLowerCase() ===
-                categoryName.trim().toLowerCase(),
-            );
-            resolvedCategoryId = retryMatched?.id ?? null;
-          } else {
-            throw createError;
-          }
-        }
+        Alert.alert("안내", "카테고리를 선택해주세요.");
+        return;
       }
 
       const newStartTime = makeTime(
@@ -656,7 +691,7 @@ export function ScheduleDetailModal({
       });
 
       setIsEditMode(false);
-      onClose(); // ← 먼저 닫고
+      onClose();
       await onUpdated();
     } catch (error: any) {
       const status = error?.response?.status;
@@ -673,11 +708,10 @@ export function ScheduleDetailModal({
   };
   return (
     <Modal visible={visible} transparent animationType="fade">
-      <KeyboardAvoidingView
-        behavior={Platform.OS === "ios" ? "padding" : undefined}
-        style={{ flex: 1 }}
-      >
-        <Pressable style={styles.detailOverlay} onPress={onClose}>
+      <View style={styles.modalRoot}>
+        <Pressable style={styles.detailOverlay} onPress={onClose} />
+
+        <View style={styles.keyboardAvoidingArea} pointerEvents="box-none">
           <Pressable
             style={styles.detailCard}
             onPress={(e) => e.stopPropagation()}
@@ -695,9 +729,13 @@ export function ScheduleDetailModal({
                       <>
                         <TouchableOpacity
                           onPress={handleEdit}
-                          style={styles.editButton}
+                          style={styles.editIconButton}
                         >
-                          <Text style={styles.editText}>수정</Text>
+                          <Ionicons
+                            name="pencil-outline"
+                            size={18}
+                            color="#405886"
+                          />
                         </TouchableOpacity>
 
                         <TouchableOpacity
@@ -756,7 +794,7 @@ export function ScheduleDetailModal({
                     <Text
                       style={[styles.tagText, { color: categoryStyle.text }]}
                     >
-                      {previewRoutine.categoryName ?? "기타"}
+                      {previewRoutine.categoryName ?? "카테고리 없음"}{" "}
                     </Text>
                   </View>
                 </View>
@@ -825,6 +863,7 @@ export function ScheduleDetailModal({
                 showsVerticalScrollIndicator={false}
                 nestedScrollEnabled
                 keyboardShouldPersistTaps="always"
+                keyboardDismissMode="on-drag"
               >
                 <View style={styles.inputBlock}>
                   <Text style={styles.editSectionLabel}>제목</Text>
@@ -1002,6 +1041,7 @@ export function ScheduleDetailModal({
                           onDecrease={() =>
                             setStartHour(getPrevHour(startHour))
                           }
+                          onChange={setStartHour}
                         />
                         <TimeStepperControl
                           label="분"
@@ -1024,70 +1064,19 @@ export function ScheduleDetailModal({
                         <TimeStepperControl
                           label="시"
                           value={endHour}
-                          onIncrease={() => {
-                            const next = getNextHour(endHour);
-                            const startTotal =
-                              Number(startHour) * 60 + Number(startMinute);
-                            const endTotal =
-                              Number(next) * 60 + Number(endMinute);
-                            if (endTotal <= startTotal) {
-                              Alert.alert(
-                                "안내",
-                                "종료 시간은 시작 시간보다 늦어야 해요.",
-                              );
-                              return;
-                            }
-                            setEndHour(next);
-                          }}
-                          onDecrease={() => {
-                            const next = getPrevHour(endHour);
-                            const startTotal =
-                              Number(startHour) * 60 + Number(startMinute);
-                            const endTotal =
-                              Number(next) * 60 + Number(endMinute);
-                            if (endTotal <= startTotal) {
-                              Alert.alert(
-                                "안내",
-                                "종료 시간은 시작 시간보다 늦어야 해요.",
-                              );
-                              return;
-                            }
-                            setEndHour(next);
-                          }}
+                          onIncrease={() => setEndHour(getNextHour(endHour))}
+                          onDecrease={() => setEndHour(getPrevHour(endHour))}
+                          onChange={setEndHour}
                         />
                         <TimeStepperControl
                           label="분"
                           value={endMinute}
-                          onIncrease={() => {
-                            const next = getNextMinute(endMinute);
-                            const startTotal =
-                              Number(startHour) * 60 + Number(startMinute);
-                            const endTotal =
-                              Number(endHour) * 60 + Number(next);
-                            if (endTotal <= startTotal) {
-                              Alert.alert(
-                                "안내",
-                                "종료 시간은 시작 시간보다 늦어야 해요.",
-                              );
-                              return;
-                            }
-                            setEndMinute(next);
-                          }}
-                          onDecrease={() => {
-                            const next = getPrevMinute(endMinute);
-                            const startTotal =
-                              Number(startHour) * 60 + Number(startMinute);
-                            const endTotal =
-                              Number(endHour) * 60 + Number(next);
-                            if (endTotal <= startTotal) {
-                              Alert.alert(
-                                "안내",
-                                "종료 시간은 시작 시간보다 늦어야 해요.",
-                              );
-                              return;
-                            }
-                            setEndMinute(next);
-                          }}
+                          onIncrease={() =>
+                            setEndMinute(getNextMinute(endMinute))
+                          }
+                          onDecrease={() =>
+                            setEndMinute(getPrevMinute(endMinute))
+                          }
                         />
                       </View>
                     </>
@@ -1116,32 +1105,45 @@ export function ScheduleDetailModal({
                   </View>
                 </View>
                 <View style={styles.inputBlock}>
-                  <Text style={styles.editSectionLabel}>반복 설정</Text>
-
-                  {/* 현재 반복 설정 표시 버튼 */}
-                  <TouchableOpacity
-                    style={styles.repeatOptionButton}
-                    onPress={() => {
-                      setShowRepeatPanel((prev) => !prev);
-                      setShowCustomRepeatPanel(false);
+                  <View
+                    style={{
+                      flexDirection: "row",
+                      justifyContent: "space-between",
+                      alignItems: "center",
+                      marginBottom: 8,
                     }}
                   >
-                    <Text style={styles.repeatOptionText}>
-                      {getRepeatLabel(
-                        repeatType,
-                        repeatInterval,
-                        repeatUnit,
-                        repeatDays,
-                      )}
+                    <Text
+                      style={[styles.editSectionLabel, { marginBottom: 0 }]}
+                    >
+                      반복 설정
                     </Text>
-                  </TouchableOpacity>
 
+                    <TouchableOpacity
+                      style={styles.repeatCurrentChip}
+                      onPress={() => {
+                        setShowRepeatPanel((prev) => !prev);
+                        setShowCustomRepeatPanel(false);
+                      }}
+                    >
+                      <View style={styles.repeatCurrentChipContent}>
+                        <Text style={styles.repeatCurrentChipText}>
+                          {getRepeatLabel(
+                            repeatType,
+                            repeatInterval,
+                            repeatUnit,
+                            repeatDays,
+                          )}
+                        </Text>
+                        <Text style={styles.repeatCurrentChevron}>▾</Text>
+                      </View>
+                    </TouchableOpacity>
+                  </View>
                   {/* 빠른 선택 패널 */}
                   {showRepeatPanel && (
                     <View style={{ marginTop: 8, gap: 6 }}>
                       {[
                         { label: "매일", value: "DAILY" as RepeatType },
-                        { label: "매주 평일", value: "WEEKDAYS" as RepeatType },
                         {
                           label: `매주 (${
                             WEEKDAY_OPTIONS.find(
@@ -1289,28 +1291,74 @@ export function ScheduleDetailModal({
                             ))}
                           </View>
                         ) : (
-                          <View style={styles.frequencyGrid}>
-                            {REPEAT_EVERY_OPTIONS.slice(0, 10).map((opt) => (
-                              <TouchableOpacity
-                                key={opt}
-                                style={[
-                                  styles.frequencyGridChip,
-                                  repeatInterval === opt &&
-                                    styles.repeatOptionButtonSelected,
-                                ]}
-                                onPress={() => setRepeatInterval(opt)}
-                              >
-                                <Text
-                                  style={[
-                                    styles.repeatOptionText,
-                                    repeatInterval === opt &&
-                                      styles.repeatOptionTextSelected,
-                                  ]}
-                                >
-                                  {opt}
-                                </Text>
-                              </TouchableOpacity>
-                            ))}
+                          <View style={styles.repeatIntervalStepper}>
+                            <TouchableOpacity
+                              style={styles.repeatStepperButton}
+                              onPress={() => {
+                                const next = Math.max(
+                                  1,
+                                  Number(repeatInterval || "1") - 1,
+                                );
+                                setRepeatInterval(String(next));
+                              }}
+                            >
+                              <Text style={styles.repeatStepperButtonText}>
+                                -
+                              </Text>
+                            </TouchableOpacity>
+
+                            <View style={styles.repeatIntervalInputBox}>
+                              <TextInput
+                                style={styles.repeatIntervalInput}
+                                value={repeatInterval}
+                                onChangeText={(text) => {
+                                  const onlyNumber = text.replace(
+                                    /[^0-9]/g,
+                                    "",
+                                  );
+                                  if (onlyNumber === "") {
+                                    setRepeatInterval("");
+                                    return;
+                                  }
+                                  setRepeatInterval(
+                                    String(
+                                      Math.min(
+                                        999,
+                                        Math.max(1, Number(onlyNumber)),
+                                      ),
+                                    ),
+                                  );
+                                }}
+                                onBlur={() => {
+                                  if (
+                                    !repeatInterval ||
+                                    Number(repeatInterval) < 1
+                                  )
+                                    setRepeatInterval("1");
+                                }}
+                                keyboardType="number-pad"
+                                returnKeyType="done"
+                                maxLength={3}
+                              />
+                              <Text style={styles.repeatIntervalSuffix}>
+                                일마다
+                              </Text>
+                            </View>
+
+                            <TouchableOpacity
+                              style={styles.repeatStepperButton}
+                              onPress={() => {
+                                const next = Math.min(
+                                  999,
+                                  Number(repeatInterval || "1") + 1,
+                                );
+                                setRepeatInterval(String(next));
+                              }}
+                            >
+                              <Text style={styles.repeatStepperButtonText}>
+                                +
+                              </Text>
+                            </TouchableOpacity>
                           </View>
                         )}
                       </View>
@@ -1370,16 +1418,22 @@ export function ScheduleDetailModal({
               </ScrollView>
             )}
           </Pressable>
-        </Pressable>
-      </KeyboardAvoidingView>
+        </View>
+      </View>
     </Modal>
   );
 }
 
 const styles = StyleSheet.create({
-  detailOverlay: {
+  modalRoot: {
     flex: 1,
+  },
+  detailOverlay: {
+    ...StyleSheet.absoluteFillObject,
     backgroundColor: "rgba(0, 0, 0, 0.4)",
+  },
+  keyboardAvoidingArea: {
+    flex: 1,
     justifyContent: "center",
     alignItems: "center",
     paddingHorizontal: 28,
@@ -1397,6 +1451,7 @@ const styles = StyleSheet.create({
     shadowOpacity: 0.1,
     shadowRadius: 30,
     elevation: 8,
+    flexShrink: 0,
   },
   detailHeader: {
     flexDirection: "row",
@@ -1681,7 +1736,7 @@ const styles = StyleSheet.create({
   },
 
   repeatOptionButton: {
-    borderWidth: 1,
+    borderWidth: 0.5,
     borderColor: "#E4E7EE",
     borderRadius: 14,
     paddingVertical: 12,
@@ -1700,14 +1755,15 @@ const styles = StyleSheet.create({
   repeatOptionTextSelected: {
     color: "#405886",
   },
-
   deleteIconButton: {
-    width: 32,
-    height: 32,
-    borderRadius: 16,
+    width: 30,
+    height: 30,
+    borderRadius: 15,
     alignItems: "center",
     justifyContent: "center",
-    backgroundColor: "#FCEBEC",
+    backgroundColor: "#F3F4F8",
+    borderWidth: 1,
+    borderColor: "#E7EAF0",
   },
 
   weekdayRow: {
@@ -1737,18 +1793,105 @@ const styles = StyleSheet.create({
     color: "#405886",
   },
 
-  frequencyGrid: {
-    flexDirection: "row",
-    flexWrap: "wrap",
-    gap: 6,
-  },
-  frequencyGridChip: {
-    width: "18%",
+  editIconButton: {
+    width: 30,
+    height: 30,
+    borderRadius: 15,
     alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#F3F4F8",
+    borderWidth: 1,
+    borderColor: "#E7EAF0",
+  },
+  timeStepperValueInput: {
+    flex: 2,
+    height: 40,
+    borderRadius: 12,
+    marginVertical: 6,
+    fontSize: 18,
+    fontWeight: "800",
+    color: "#2A3C6B",
+    textAlign: "center",
+    includeFontPadding: false,
+    lineHeight: 20,
+  },
+
+  repeatCurrentChip: {
+    minHeight: 28,
+    borderRadius: 14,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    backgroundColor: "#F3F5FA",
     borderWidth: 1,
     borderColor: "#E4E7EE",
-    borderRadius: 14,
-    paddingVertical: 10,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+
+  repeatCurrentChipContent: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 4,
+  },
+
+  repeatCurrentChipText: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: "#405886",
+  },
+
+  repeatCurrentChevron: {
+    fontSize: 10,
+    fontWeight: "900",
+    color: "#9AA3B2",
+    marginTop: -1,
+  },
+  repeatIntervalStepper: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 8,
+  },
+  repeatStepperButton: {
+    width: 34,
+    height: 34,
+    borderRadius: 17,
+    alignItems: "center",
+    justifyContent: "center",
+    backgroundColor: "#F3F4F8",
+    borderWidth: 1,
+    borderColor: "#E4E7EE",
+  },
+  repeatStepperButtonText: {
+    fontSize: 18,
+    fontWeight: "700",
+    color: "#405886",
+  },
+  repeatIntervalInputBox: {
+    flex: 1,
+    height: 34,
+    borderRadius: 17,
+    borderWidth: 1,
+    borderColor: "#E7EAF3",
     backgroundColor: "#FAFBFD",
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+    paddingHorizontal: 10,
+  },
+  repeatIntervalInput: {
+    minWidth: 28,
+    maxWidth: 52,
+    paddingVertical: 0,
+    paddingHorizontal: 0,
+    fontSize: 14,
+    fontWeight: "700",
+    color: "#2F3550",
+    textAlign: "center",
+  },
+  repeatIntervalSuffix: {
+    marginLeft: 4,
+    fontSize: 13,
+    fontWeight: "700",
+    color: "#6D7690",
   },
 });

--- a/lib/routine_mapper.ts
+++ b/lib/routine_mapper.ts
@@ -25,7 +25,7 @@ export const toScheduleRoutine = (
   endTime: api.endTime,
   startDate: api.startAt,
   endDate: api.endAt,
-  state: true,
+  state: api.isCompleted,
   completedDates,
 });
 // 로컬 타입 → API 요청으로 변환


### PR DESCRIPTION
## 관련 이슈

- Closes #71 
- Closes #65 

---

## 작업 내용

 상세 모달
- 수정 버튼을 텍스트 버튼 → 아이콘 버튼 형태로 변경
카테고리 화면
- 진행중/완료 표시 영역에서 아이콘 겹침 수정
- 카테고리 순서 변경 시 드래그 애니메이션 튕김 강도 조정
- 앱 내부에 고정되어 있던 기본 카테고리 제거
- 상단에 “카테고리” 페이지 타이틀 추가하여 화면 목적 명확화
- 기존 우측 상단 + 버튼 제거 후 진행중/완료 탭바 영역 확장
- “카테고리 추가” 버튼을 진행중/완료 탭 하단으로 이동
- 카테고리 카드 내부 루틴 영역 우측에 + 버튼 추가
> - 버튼 클릭 시 루틴 추가 모달 이동
> - 선택된 카테고리가 모달 기본값으로 자동 적용되도록 수정

- 카테고리 추가/수정 모달에서 키보드 등장 시 좌우 여백이 생기던 UI 문제 수정

기타 수정 사항
- modal.tsx 내부 기존 기본 카테고리 관련 코드 정리 및 제거
- 루틴 수정 모달에서도 기존 기본 카테고리 제거 로직 반영
- 루틴 추가 모달 반복 설정 UI를 수정 모달과 동일한 구조로 통일
- 루틴 추가/수정 모달 모두 반복 설정의 “일 단위 빈도”를
> -스테퍼 , 키보드 직접 입력 두 방식 모두 가능하도록 수정
- 수정 모달에서도 기존 스테퍼 입력만 가능하던 시간 설정 구조를 키보드 입력도 가능하도록 개선
- 상세 모달 및 추가/수정 모달에서 401 / 403 인증 에러 처리 추가
- 타임테이블 하단 카테고리 영역을 서버 데이터 기반으로 변경하여 실제 카테고리 목록 표시

---

## 테스트 체크리스트

카테고리 화면
 - [x] 기본 카테고리가 자동 생성되지 않는지 확인
 - [x] 상단 “카테고리” 타이틀이 정상 표시되는지 확인
 - [x] 진행중/완료 탭바가 전체 너비에 맞게 확장되었는지 확인
 - [x] “카테고리 추가” 버튼 위치 및 동작 확인
 - [x] 카테고리 내부 + 버튼 클릭 시 루틴 추가 모달이 열리는지 확인
 - [x] 카테고리 내부 + 버튼 클릭 시 해당 카테고리가 기본 선택되는지 확인
 - [x] 카테고리 추가/수정 모달에서 키보드 등장 시 좌우 여백이 생기지 않는지 확인
반복 설정 / 모달
 - [x] 반복 빈도를 스테퍼로 변경 가능한지 확인
 - [x] 반복 빈도를 키보드로 직접 입력 가능한지 확인
 - [x] 수정 모달에서 시간 설정 키보드 입력이 정상 동작하는지 확인

- [x]  타임테이블 하단 카테고리가 서버 데이터 기준으로 정상 표시되는지 확인

---

## 참고사항

-
