### PR TITLE
feat: 무한반복 루틴/ 로컬 알림/통계 필터링/ 루틴 겹침 확인 UI

### DIFF
--- a/app/(tabs)/category.tsx
+++ b/app/(tabs)/category.tsx
@@ -8,7 +8,6 @@ import {
   uniqueColors,
   type CustomCategory,
 } from "@/lib/category";
-import { getRoutineOccurrenceDates } from "@/lib/storage";
 import type { Category } from "@/services/category_service";
 import { CategoryService } from "@/services/category_service";
 import { RoutineService } from "@/services/routine_service";
@@ -105,46 +104,9 @@ const normalizeDate = (date?: string | null) => {
 
 // 루틴이 완료 상태인지 판단
 const isRoutineCompleted = (routine: ScheduleRoutine): boolean => {
-  const startDate = normalizeDate(routine.startDate);
   const endDate = normalizeDate(routine.endDate);
-
-  // 1. 기간이 끝난 루틴은 완료 처리
-  if (isPastEndDate(endDate)) return true;
-
-  const completedDates = routine.completedDates ?? [];
-  const normalizedCompletedDates = completedDates.map(normalizeDate);
-
-  // 2. 오늘 시작해서 오늘 끝나는 단일 날짜 루틴
-  if (startDate === endDate) {
-    return (
-      normalizedCompletedDates.includes(startDate) || routine.state === true
-    );
-  }
-
-  const today = getTodayString();
-  const effectiveEnd = endDate || today;
-
-  const allDates = getRoutineOccurrenceDates(
-    {
-      ...routine,
-      startDate,
-      endDate,
-    },
-    startDate,
-    effectiveEnd,
-  );
-
-  // 3. 반복 날짜가 없으면 state 기준으로라도 완료 판단
-  if (allDates.length === 0) {
-    return routine.state === true;
-  }
-
-  // 4. 기간 안의 모든 반복 날짜가 완료됐으면 완료 처리
-  return allDates.every((date) =>
-    normalizedCompletedDates.includes(normalizeDate(date)),
-  );
+  return isPastEndDate(endDate); // endDate가 오늘 이전이면 완료
 };
-
 const loadRoutines = async () => {
   return RoutineService.getAll();
 };
@@ -1148,7 +1110,6 @@ export default function CategoryScreen() {
           )}
         </View>
 
-        {/* 카테고리 추가/수정 바텀시트 모달 */}
         {/* 카테고리 추가/수정 바텀시트 모달 */}
         <Modal
           visible={isCategoryModalVisible}

--- a/app/(tabs)/data.tsx
+++ b/app/(tabs)/data.tsx
@@ -426,17 +426,42 @@ export default function DataScreen() {
     }, [loadHeatmap]),
   );
   const groupedRoutines = useMemo(() => {
+    // 현재 뷰모드에 따라 선택된 기간의 시작/끝 날짜 계산
+    let periodStart: Date;
+    let periodEnd: Date;
+
+    if (viewMode === "YEAR") {
+      periodStart = new Date(selectedYear, 0, 1);
+      periodEnd = new Date(selectedYear, 11, 31);
+    } else if (viewMode === "MONTH") {
+      periodStart = new Date(selectedYear, selectedMonth, 1);
+      periodEnd = new Date(selectedYear, selectedMonth + 1, 0);
+    } else {
+      periodStart = getWeekStart(selectedWeekDate);
+      periodEnd = getWeekEnd(selectedWeekDate);
+    }
+
+    // startAt~endAt이 현재 선택된 기간과 겹치는 루틴만 필터링
+    const filtered = heatmapData.filter((routine) => {
+      const routineStart = new Date(routine.startAt);
+      const routineEnd = routine.endAt
+        ? new Date(routine.endAt)
+        : new Date(9999, 11, 31);
+      // 기간 겹침 조건: routineStart <= periodEnd && routineEnd >= periodStart
+      return routineStart <= periodEnd && routineEnd >= periodStart;
+    });
+
     const groupedMap = new Map<string, HeatmapRoutine[]>();
-    heatmapData.forEach((routine) => {
+    filtered.forEach((routine) => {
       const categoryName = routine.category.name;
       const prev = groupedMap.get(categoryName) ?? [];
       groupedMap.set(categoryName, [...prev, routine]);
     });
+
     return Array.from(groupedMap.entries())
       .map(([categoryName, routines]) => ({ categoryName, routines }))
       .sort((a, b) => a.categoryName.localeCompare(b.categoryName, "ko"));
-  }, [heatmapData]);
-
+  }, [heatmapData, viewMode, selectedYear, selectedMonth, selectedWeekDate]);
   // 새로 생긴 카테고리는 기본적으로 펼쳐진 상태로 설정
   React.useEffect(() => {
     setExpandedCategories((prev) => {

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,7 +1,6 @@
 import ScheduleContent from "@/components/schedule_content";
 import { Header } from "@/components/ui/_header";
 import AppCalendar from "@/components/ui/app_calendar";
-
 import { RoutineService } from "@/services/routine_service";
 import { authStore } from "@/store/authStore";
 import type { MarkedDates } from "@/types/calendar";
@@ -17,6 +16,7 @@ import React, {
   useState,
 } from "react";
 import {
+  Alert,
   Dimensions,
   NativeScrollEvent,
   NativeSyntheticEvent,
@@ -31,7 +31,7 @@ import {
 import "react-native-gesture-handler";
 
 const SCREEN_WIDTH = Dimensions.get("window").width;
-// 시간표에 표시할 일정 타입
+
 type TimetableEvent = {
   id: string;
   title: string;
@@ -40,25 +40,19 @@ type TimetableEvent = {
   type: string;
   color?: string;
 };
-// HEX 색상에 투명도 값 추가
+
 function addAlphaToHex(hexColor: string, alpha = "22") {
   if (!hexColor.startsWith("#")) return "#F1F1FB";
   if (hexColor.length === 7) return `${hexColor}${alpha}`;
   return hexColor;
 }
-// 시간을 분 단위로 변환
-function parseTimeToMinutes(time?: string | null) {
-  // "09:30", "09:30:00" 둘 다 대응
-  if (!time) return null;
 
+function parseTimeToMinutes(time?: string | null) {
+  if (!time) return null;
   const parts = time.split(":");
   const hour = Number(parts[0]);
   const minute = Number(parts[1]);
-
-  if (Number.isNaN(hour) || Number.isNaN(minute)) {
-    return null;
-  }
-
+  if (Number.isNaN(hour) || Number.isNaN(minute)) return null;
   return hour * 60 + minute;
 }
 
@@ -66,12 +60,10 @@ function buildTimetableEvents(routines: ScheduleRoutine[]): TimetableEvent[] {
   const events: TimetableEvent[] = [];
   routines.forEach((routine) => {
     if (!routine.startTime || !routine.endTime) return;
-
     const startMinute = parseTimeToMinutes(routine.startTime);
     const endMinute = parseTimeToMinutes(routine.endTime);
     if (startMinute === null || endMinute === null) return;
     if (endMinute <= startMinute) return;
-
     events.push({
       id: String(routine.id),
       title: routine.title,
@@ -83,9 +75,9 @@ function buildTimetableEvents(routines: ScheduleRoutine[]): TimetableEvent[] {
   });
   return events.sort((a, b) => a.startMinute - b.startMinute);
 }
+
 function getEventStyle(type: string, color?: string) {
   const fallbackColor = color || "#9FA2D6";
-
   return {
     bg: addAlphaToHex(fallbackColor),
     dot: fallbackColor,
@@ -104,41 +96,32 @@ export default function HomeScreen() {
   const [currentTime, setCurrentTime] = useState(new Date());
   // 저장소에서 불러온 전체 루틴
   const [storedRoutines, setStoredRoutines] = useState<ScheduleRoutine[]>([]);
+  const scheduleReloadRef = useRef<(() => Promise<void>) | null>(null);
 
   const startHour = 0;
   const endHour = 24;
   const hourHeight = 60;
-
   const hours = Array.from(
     { length: endHour - startHour },
     (_, i) => startHour + i,
   );
   const columns = [0, 1, 2, 3, 4, 5];
-  // 시간표 스크롤 위치 제어용 ref
   const timetableScrollRef = useRef<ScrollView>(null);
 
   const currentDateString = format(currentDate, "yyyy-MM-dd");
-  // 현재 선택된 날짜가 포함된 주 계산
   const startOfCurrentWeek = startOfWeek(currentDate, { weekStartsOn: 0 });
   const weekDays = Array.from({ length: 7 }).map((_, i) =>
     addDays(startOfCurrentWeek, i),
   );
 
-  //  수직 이동이 수평 이동보다 클 때만 반응
   const panResponder = useRef(
     PanResponder.create({
-      onMoveShouldSetPanResponder: (_, gestureState) => {
-        return (
-          Math.abs(gestureState.dy) > 10 &&
-          Math.abs(gestureState.dy) > Math.abs(gestureState.dx)
-        );
-      },
+      onMoveShouldSetPanResponder: (_, gestureState) =>
+        Math.abs(gestureState.dy) > 10 &&
+        Math.abs(gestureState.dy) > Math.abs(gestureState.dx),
       onPanResponderRelease: (_, gestureState) => {
-        if (gestureState.dy > 40) {
-          setIsCalendarVisible(true);
-        } else if (gestureState.dy < -40) {
-          setIsCalendarVisible(false);
-        }
+        if (gestureState.dy > 40) setIsCalendarVisible(true);
+        else if (gestureState.dy < -40) setIsCalendarVisible(false);
       },
     }),
   ).current;
@@ -156,17 +139,16 @@ export default function HomeScreen() {
       setStoredRoutines([]);
     }
   }, [currentDateString]);
-  // 다른 화면 갔다가 돌아올 때 최신 루틴 다시 불러오기
+
   useFocusEffect(
     useCallback(() => {
       loadStoredRoutines();
     }, [loadStoredRoutines]),
   );
-  // 현재 시간 기준으로 시간표 위치 이동 + 1분마다 현재 시간 갱신
-  useEffect(() => {
-    const currentHour = currentTime.getHours();
-    const yOffset = Math.max(0, (currentHour - startHour - 1) * hourHeight);
 
+  useEffect(() => {
+    const currentHour = new Date().getHours();
+    const yOffset = Math.max(0, (currentHour - startHour - 1) * hourHeight);
     const timeout = setTimeout(() => {
       timetableScrollRef.current?.scrollTo({ y: yOffset, animated: true });
     }, 100);
@@ -179,53 +161,79 @@ export default function HomeScreen() {
       clearTimeout(timeout);
       clearInterval(interval);
     };
-  }, [currentTime, startHour, hourHeight]);
-
-  // 가로 스와이프가 끝났을 때 현재 페이지 상태 변경
+  }, []); //  마운트 시 1번만 실행
   const handleHorizontalScrollEnd = (
     event: NativeSyntheticEvent<NativeScrollEvent>,
   ) => {
     const pageWidth = SCREEN_WIDTH - 32;
     const offsetX = event.nativeEvent.contentOffset.x;
     const currentPage = Math.round(offsetX / pageWidth);
-
     setActivePage(currentPage === 0 ? "left" : "right");
   };
-  // 현재 선택 날짜에 시간표로 보여줄 일정 목록
-  const timetableEvents = useMemo(() => {
-    return buildTimetableEvents(storedRoutines);
-  }, [storedRoutines]);
+
+  const timetableEvents = useMemo(
+    () => buildTimetableEvents(storedRoutines),
+    [storedRoutines],
+  );
 
   const calendarMarkedDates = useMemo(() => {
     const marked: MarkedDates = {
       [currentDateString]: { selected: true, selectedColor: "#F1F1FB" },
     };
-
     return marked;
   }, [currentDateString]);
 
   const legendItems = useMemo(() => {
     const uniqueMap = new Map<string, { label: string; dot: string }>();
-
     timetableEvents.forEach((event) => {
       const style = getEventStyle(event.type, event.color);
       if (!uniqueMap.has(event.type)) {
-        uniqueMap.set(event.type, {
-          label: event.type,
-          dot: style.dot,
-        });
+        uniqueMap.set(event.type, { label: event.type, dot: style.dot });
       }
     });
-
     return Array.from(uniqueMap.values());
   }, [timetableEvents]);
+
+  const handleEventPress = useCallback(
+    async (event: TimetableEvent) => {
+      const routine = storedRoutines.find((r) => String(r.id) === event.id);
+      const isCompleted =
+        routine?.completedDates?.includes(currentDateString) ?? false;
+
+      Alert.alert(
+        isCompleted ? "완료 취소" : "루틴 완료",
+        isCompleted
+          ? `'${event.title}' 루틴의 완료를 취소할까요?`
+          : `'${event.title}' 루틴을 완료 처리할까요?`,
+        [
+          { text: "취소", style: "cancel" },
+          {
+            text: isCompleted ? "취소하기" : "완료",
+            style: isCompleted ? "destructive" : "default",
+            onPress: async () => {
+              try {
+                await RoutineService.toggleComplete(
+                  Number(event.id),
+                  currentDateString,
+                );
+                await loadStoredRoutines();
+                await scheduleReloadRef.current?.();
+              } catch (error) {
+                console.error("루틴 완료 처리 실패", error);
+                Alert.alert("오류", "처리에 실패했습니다.");
+              }
+            },
+          },
+        ],
+      );
+    },
+    [currentDateString, loadStoredRoutines, storedRoutines],
+  );
 
   return (
     <SafeAreaView style={styles.safeArea}>
       <View style={styles.container}>
-        {/* 현재 페이지에 따라 헤더의 토글 표시 변경 */}
         <Header activeTab={activePage} />
-        {/* 타임테이블과 일정 화면을 가로 스와이프로 전환 */}
         <ScrollView
           horizontal
           pagingEnabled
@@ -237,8 +245,9 @@ export default function HomeScreen() {
           {/* 타임테이블 */}
           <View style={styles.page}>
             <View style={styles.mainCard}>
+              {/* 상단 패널: 주간 날짜 + 핸들 + 월간 캘린더 */}
               <View style={styles.topPanel} {...panResponder.panHandlers}>
-                {/* 주간 날짜 선택 영역 */}
+                {/* 주간 날짜 선택 */}
                 <View style={styles.daySelector}>
                   {weekDays.map((date) => {
                     const isSelected = isSameDay(date, currentDate);
@@ -258,7 +267,6 @@ export default function HomeScreen() {
                         >
                           {dayStr}
                         </Text>
-
                         <View
                           style={[
                             styles.dateCircle,
@@ -278,7 +286,8 @@ export default function HomeScreen() {
                     );
                   })}
                 </View>
-                {/* 캘린더 열기/닫기 핸들 영역 */}
+
+                {/* 스와이프 핸들 + 오늘 버튼 */}
                 <View style={styles.handleRow}>
                   <TouchableOpacity
                     style={styles.swipeHandleContainer}
@@ -287,7 +296,6 @@ export default function HomeScreen() {
                   >
                     <View style={styles.swipeHandle} />
                   </TouchableOpacity>
-                  {/* 오늘이 아닌 날짜를 보고 있을 때만 오늘 버튼 표시 */}
                   {!isSameDay(currentDate, new Date()) && (
                     <TouchableOpacity
                       style={styles.todayButton}
@@ -300,6 +308,7 @@ export default function HomeScreen() {
                     </TouchableOpacity>
                   )}
                 </View>
+
                 {/* 월간 캘린더 */}
                 {isCalendarVisible && (
                   <View style={styles.calendarWrapper}>
@@ -314,29 +323,48 @@ export default function HomeScreen() {
                   </View>
                 )}
               </View>
-              {/* 시간표 영역 */}
+              {/* ── topPanel 끝 ── */}
+
+              {/* 시간표 스크롤 영역 */}
               <ScrollView
                 ref={timetableScrollRef}
                 style={styles.timetableContainer}
                 showsVerticalScrollIndicator={false}
               >
                 <View style={styles.timetableInner}>
-                  {/* 왼쪽 시간 축 */}
+                  {/* 시간 축 */}
                   <View style={styles.timeAxis}>
-                    {hours.map((hour) => (
-                      <View
-                        key={hour}
-                        style={[
-                          styles.timeLabelContainer,
-                          { height: hourHeight },
-                        ]}
-                      >
-                        <Text style={styles.timeLabel}>{hour}</Text>
-                      </View>
-                    ))}
+                    {hours.map((hour) => {
+                      const isCurrentHour =
+                        isSameDay(currentDate, new Date()) &&
+                        hour === currentTime.getHours();
+                      const label = isCurrentHour
+                        ? `${String(currentTime.getHours()).padStart(2, "0")}:${String(currentTime.getMinutes()).padStart(2, "0")}`
+                        : String(hour);
+                      return (
+                        <View
+                          key={hour}
+                          style={[
+                            styles.timeLabelContainer,
+                            { height: hourHeight },
+                          ]}
+                        >
+                          <Text
+                            style={[
+                              styles.timeLabel,
+                              isCurrentHour && styles.timeLabelCurrent,
+                            ]}
+                          >
+                            {label}
+                          </Text>
+                        </View>
+                      );
+                    })}
                   </View>
-                  {/* 시간표 그리드 영역 */}
+
+                  {/* 그리드 영역 */}
                   <View style={styles.gridArea}>
+                    {/* hour 행 */}
                     {hours.map((hour) => (
                       <View
                         key={hour}
@@ -351,31 +379,26 @@ export default function HomeScreen() {
                             ]}
                           />
                         ))}
-                        {/* 해당 시간 줄에 걸치는 일정 블록 표시 */}
+
+                        {/* 이벤트 블록 */}
                         {timetableEvents.map((event) => {
                           const hourStart = hour * 60;
                           const hourEnd = hourStart + 60;
-
-                          // 현재 hour 줄에 걸치는 일정만 표시
                           if (
                             event.startMinute >= hourEnd ||
                             event.endMinute <= hourStart
-                          ) {
+                          )
                             return null;
-                          }
 
                           const overlapStart = Math.max(
                             event.startMinute,
                             hourStart,
                           );
                           const overlapEnd = Math.min(event.endMinute, hourEnd);
-
-                          const startOffsetMin = overlapStart - hourStart;
-                          const durationInHour = overlapEnd - overlapStart;
-
-                          const leftPercent = (startOffsetMin / 60) * 100;
-                          const widthPercent = (durationInHour / 60) * 100;
-
+                          const leftPercent =
+                            ((overlapStart - hourStart) / 60) * 100;
+                          const widthPercent =
+                            ((overlapEnd - overlapStart) / 60) * 100;
                           const typeStyles = getEventStyle(
                             event.type,
                             event.color,
@@ -384,8 +407,10 @@ export default function HomeScreen() {
                             overlapStart === event.startMinute;
 
                           return (
-                            <View
+                            <TouchableOpacity
                               key={`${event.id}-${hour}`}
+                              activeOpacity={0.75}
+                              onPress={() => handleEventPress(event)}
                               style={[
                                 styles.eventBlock,
                                 {
@@ -406,27 +431,41 @@ export default function HomeScreen() {
                                   {event.title}
                                 </Text>
                               )}
-                            </View>
+                            </TouchableOpacity>
                           );
                         })}
-                        {/* 오늘 날짜일 때 현재 시간 위치 표시 */}
-                        {isSameDay(currentDate, new Date()) &&
-                          hour === currentTime.getHours() && (
-                            <View
-                              style={[
-                                styles.currentTimeIndicator,
-                                {
-                                  left: `${(currentTime.getMinutes() / 60) * 100}%`,
-                                },
-                              ]}
-                            />
-                          )}
                       </View>
                     ))}
+
+                    {/* 현재 시간 인디케이터 — gridArea 기준 절대 위치 */}
+                    {/* 현재 시간 인디케이터 */}
+                    {isSameDay(currentDate, new Date()) &&
+                      (() => {
+                        const currentHour = currentTime.getHours();
+                        const currentMinute = currentTime.getMinutes();
+                        const leftPercent = (currentMinute / 60) * 100;
+
+                        return (
+                          <View
+                            pointerEvents="none"
+                            style={[
+                              styles.currentTimeIndicator,
+                              {
+                                left: `${leftPercent}%`,
+                                top: (currentHour - startHour) * hourHeight,
+                                height: hourHeight,
+                              },
+                            ]}
+                          />
+                        );
+                      })()}
                   </View>
+                  {/* ── gridArea 끝 ── */}
                 </View>
               </ScrollView>
-              {/* 카테고리 범례 */}
+              {/* ── 시간표 ScrollView 끝 ── */}
+
+              {/* 범례 */}
               <View style={styles.legendContainer}>
                 {legendItems.map((item) => (
                   <View key={item.label} style={styles.legendItem}>
@@ -439,10 +478,16 @@ export default function HomeScreen() {
               </View>
             </View>
           </View>
+          {/* ── 타임테이블 페이지 끝 ── */}
 
-          {/* 일정 */}
+          {/* ── 일정 페이지 ── */}
           <View style={styles.page}>
-            <ScheduleContent />
+            <ScheduleContent
+              onToggleComplete={(reload) => {
+                scheduleReloadRef.current = reload;
+              }}
+              onRoutineUpdated={loadStoredRoutines}
+            />
           </View>
         </ScrollView>
       </View>
@@ -451,23 +496,15 @@ export default function HomeScreen() {
 }
 
 const styles = StyleSheet.create({
-  safeArea: {
-    flex: 1,
-    backgroundColor: "#F3F4F8",
-  },
+  safeArea: { flex: 1, backgroundColor: "#F3F4F8" },
   container: {
     flex: 1,
     paddingHorizontal: 16,
     paddingTop: 10,
     backgroundColor: "#F3F4F8",
   },
-  horizontalContent: {
-    flexGrow: 1,
-  },
-  page: {
-    width: SCREEN_WIDTH - 32,
-    flex: 1,
-  },
+  horizontalContent: { flexGrow: 1 },
+  page: { width: SCREEN_WIDTH - 32, flex: 1 },
   mainCard: {
     flex: 1,
     backgroundColor: "#FFFFFF",
@@ -491,11 +528,7 @@ const styles = StyleSheet.create({
     borderRadius: 14,
     zIndex: 20,
   },
-  todayButtonText: {
-    fontSize: 12,
-    color: "#2A3C6B",
-    fontWeight: "700",
-  },
+  todayButtonText: { fontSize: 12, color: "#2A3C6B", fontWeight: "700" },
   daySelector: {
     flexDirection: "row",
     justifyContent: "space-between",
@@ -510,26 +543,16 @@ const styles = StyleSheet.create({
     paddingVertical: 8,
     borderRadius: 16,
   },
-  dateCircleSelected: {
-    backgroundColor: "#A0B0D0",
-  },
+  dateCircleSelected: { backgroundColor: "#A0B0D0" },
   dayText: {
     fontSize: 13,
     color: "#A0A7B4",
     fontWeight: "600",
     marginBottom: 4,
   },
-  dateText: {
-    fontSize: 16,
-    color: "#405886",
-    fontWeight: "700",
-  },
-  dayTextSelected: {
-    color: "#405886",
-  },
-  dateTextSelected: {
-    color: "#FFFFFF",
-  },
+  dateText: { fontSize: 16, color: "#405886", fontWeight: "700" },
+  dayTextSelected: { color: "#405886" },
+  dateTextSelected: { color: "#FFFFFF" },
   dateCircle: {
     width: 30,
     height: 30,
@@ -538,7 +561,6 @@ const styles = StyleSheet.create({
     alignItems: "center",
     marginBottom: 6,
   },
-
   handleRow: {
     position: "relative",
     justifyContent: "center",
@@ -546,9 +568,7 @@ const styles = StyleSheet.create({
     paddingTop: 6,
     paddingBottom: 14,
   },
-  swipeHandleContainer: {
-    padding: 10,
-  },
+  swipeHandleContainer: { padding: 10 },
   swipeHandle: {
     width: 40,
     height: 4,
@@ -563,32 +583,20 @@ const styles = StyleSheet.create({
     paddingBottom: 10,
     marginHorizontal: 16,
   },
-  timetableContainer: {
-    paddingTop: 15,
-    flex: 1,
-  },
-  timetableInner: {
-    flexDirection: "row",
-    paddingHorizontal: 10,
-  },
-  timeAxis: {
-    width: 40,
-    paddingRight: 10,
-  },
-  timeLabelContainer: {
-    justifyContent: "center",
-    alignItems: "center",
-  },
-  timeLabel: {
-    fontSize: 14,
-    color: "#A0B0D0",
-  },
+  timetableContainer: { paddingTop: 15, flex: 1 },
+  timetableInner: { flexDirection: "row", paddingHorizontal: 10 },
+  timeAxis: { width: 52, paddingRight: 4 },
+  timeLabelContainer: { justifyContent: "center", alignItems: "center" },
+  timeLabel: { fontSize: 14, color: "#A0B0D0" },
+  timeLabelCurrent: { color: "#6C7FD8", fontWeight: "700", fontSize: 11 },
   gridArea: {
     flex: 1,
     borderLeftWidth: 1,
     borderTopWidth: 1,
     borderRightWidth: 1,
     borderColor: "#EDEEF1",
+    position: "relative",
+    overflow: "visible",
   },
   hourRow: {
     flexDirection: "row",
@@ -609,18 +617,15 @@ const styles = StyleSheet.create({
     justifyContent: "center",
     paddingHorizontal: 10,
   },
-  eventTitle: {
-    fontSize: 13,
-    fontWeight: "600",
-  },
+  eventTitle: { fontSize: 13, fontWeight: "600" },
   currentTimeIndicator: {
     position: "absolute",
-    top: 0,
-    bottom: 0,
     width: 2,
-    backgroundColor: "#c5e4af",
+    backgroundColor: "#6C7FD8",
     zIndex: 10,
+    borderRadius: 1,
   },
+
   legendContainer: {
     flexDirection: "row",
     justifyContent: "center",
@@ -629,19 +634,7 @@ const styles = StyleSheet.create({
     marginTop: 20,
     paddingHorizontal: 20,
   },
-  legendItem: {
-    flexDirection: "row",
-    alignItems: "center",
-    gap: 6,
-  },
-  legendDot: {
-    width: 10,
-    height: 10,
-    borderRadius: 5,
-  },
-  legendText: {
-    fontSize: 13,
-    color: "#8A8C9A",
-    fontWeight: "500",
-  },
+  legendItem: { flexDirection: "row", alignItems: "center", gap: 6 },
+  legendDot: { width: 10, height: 10, borderRadius: 5 },
+  legendText: { fontSize: 13, color: "#8A8C9A", fontWeight: "500" },
 });

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,6 +16,8 @@ import AsyncStorage from "@react-native-async-storage/async-storage";
 import * as SplashScreen from "expo-splash-screen";
 
 import { useColorScheme } from "@/hooks/use-color-scheme";
+import { NotificationService } from "@/services/notification_service";
+import { RoutineService } from "@/services/routine_service";
 import { authStore } from "@/store/authStore";
 import { useFonts } from "expo-font";
 import { useEffect, useState } from "react";
@@ -40,11 +42,17 @@ export default function RootLayout() {
   const [isReady, setIsReady] = useState(false);
   const [isLoggedIn, setIsLoggedIn] = useState(authStore.isLoggedIn);
   const [isNavigationReady, setIsNavigationReady] = useState(false);
+  const [hasRestoredNotifications, setHasRestoredNotifications] =
+    useState(false);
   const navigationState = useRootNavigationState();
   const inAuthGroup = segments[0] === "onboarding";
   useEffect(() => {
     return authStore.subscribe(() => {
       setIsLoggedIn(authStore.isLoggedIn);
+
+      if (!authStore.isLoggedIn) {
+        setHasRestoredNotifications(false);
+      }
     });
   }, []);
 
@@ -65,7 +73,28 @@ export default function RootLayout() {
 
     checkLoginStatus();
   }, []);
+  // 로그인 상태가 복구된 후 서버 루틴 기준으로 로컬 알림 재예약
+  useEffect(() => {
+    const restoreRoutineNotifications = async () => {
+      if (!isLoggedIn || hasRestoredNotifications) return;
 
+      try {
+        const routines = await RoutineService.getAll();
+
+        for (const routine of routines) {
+          if (routine.alarm && routine.startTime) {
+            await NotificationService.syncRoutineNotification(routine);
+          }
+        }
+
+        setHasRestoredNotifications(true);
+      } catch (error) {
+        console.warn("루틴 알림 복구 실패", error);
+      }
+    };
+
+    restoreRoutineNotifications();
+  }, [isLoggedIn, hasRestoredNotifications]);
   useEffect(() => {
     // 2. 엔진이 준비되지 않았거나 아직 데이터가 로드되지 않았다면 중단
     if (!navigationState?.key || !loaded || !isReady) return;

--- a/app/modal.tsx
+++ b/app/modal.tsx
@@ -7,12 +7,14 @@ import { IconSymbol } from "@/components/ui/icon-symbol";
 import { useRoutineForm } from "@/hooks/use_routine_form";
 import { type CustomCategory } from "@/lib/category";
 import { CategoryService } from "@/services/category_service";
+import { RoutineService } from "@/services/routine_service";
 import type {
   NotifyOption,
   RepeatType,
   RepeatUnit,
   RepeatWeekday,
   SaveRoutineOptions,
+  ScheduleRoutine,
 } from "@/types/routine";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useLocalSearchParams, useRouter } from "expo-router";
@@ -270,10 +272,19 @@ export default function ModalScreen() {
   const [activeDateField, setActiveDateField] = useState<"start" | "end">(
     "start",
   );
+  const [existingRoutines, setExistingRoutines] = useState<ScheduleRoutine[]>(
+    [],
+  );
+  const [previewDateField, setPreviewDateField] = useState<"start" | "end">(
+    "start",
+  );
+  const [showExistingRoutines, setShowExistingRoutines] = useState(false);
+
   //바텀시트 드래그 애니메이션
   const translateY = useRef(new Animated.Value(0)).current;
   const closeThreshold = 120;
-
+  const scrollViewRef = useRef<ScrollView>(null);
+  const scrollOffsetRef = useRef(0);
   const {
     title,
     setTitle,
@@ -282,6 +293,7 @@ export default function ModalScreen() {
     selectedColor,
     setSelectedColor,
     selectedDate,
+
     setSelectedDate,
     isTimed,
     setIsTimed,
@@ -299,6 +311,7 @@ export default function ModalScreen() {
   } = useRoutineForm(() => router.dismiss());
   const [startDate, setStartDate] = useState(selectedDate);
   const [endDate, setEndDate] = useState(selectedDate);
+  const previewDate = previewDateField === "start" ? startDate : endDate;
 
   // AI 추천 데이터 연동
   useEffect(() => {
@@ -344,6 +357,8 @@ export default function ModalScreen() {
         if (draft.startMinute) setStartMinute(draft.startMinute);
         if (draft.endHour) setEndHour(draft.endHour);
         if (draft.endMinute) setEndMinute(draft.endMinute);
+        if (typeof draft.hasEndDate === "boolean")
+          setHasEndDate(draft.hasEndDate);
       } catch (error) {
         console.error("draft 복원 실패", error);
       }
@@ -368,7 +383,7 @@ export default function ModalScreen() {
   const [repeatUnit, setRepeatUnit] = useState<RepeatUnit>("DAY");
   // 주 단위 사용자 반복에서 선택한 요일 저장
   const [repeatDays, setRepeatDays] = useState<RepeatWeekday[]>([]);
-
+  const [hasEndDate, setHasEndDate] = useState(true);
   //커스텀 카테고리 이름 -> 색상 맵
   const customCategoryColorMap = useMemo(() => {
     return customCategories.reduce<Record<string, string>>((acc, item) => {
@@ -413,10 +428,8 @@ export default function ModalScreen() {
   }, [repeatType, repeatInterval, repeatUnit, repeatDays]);
 
   const isInvalidDateRange = useMemo(() => {
-    // 종료일이 시작일보다 빠른지 미리 검사
-    return endDate < startDate;
-  }, [startDate, endDate]);
-
+    return hasEndDate && endDate < startDate;
+  }, [startDate, endDate, hasEndDate]);
   //날짜 선택
   const handleDayPress = (day: DateData) => {
     if (activeDateField === "start") {
@@ -444,7 +457,18 @@ export default function ModalScreen() {
         setCustomCategories([]);
       });
   }, []);
+  // 날짜 바뀔 때마다 해당 날짜 루틴 불러오기
+  useEffect(() => {
+    RoutineService.getAll(previewDate)
+      .then(setExistingRoutines)
+      .catch(() => setExistingRoutines([]));
+  }, [previewDate]);
 
+  // 겹치는 루틴 있으면 자동으로 펼치기
+  useEffect(() => {
+    const hasConflict = existingRoutines.some((r) => isTimeConflict(r));
+    if (hasConflict) setShowExistingRoutines(true);
+  }, [existingRoutines, startHour, startMinute, endHour, endMinute, isTimed]);
   const saveDraftRef = useRef<() => Promise<void>>(async () => {});
 
   saveDraftRef.current = async () => {
@@ -462,6 +486,7 @@ export default function ModalScreen() {
       startMinute,
       endHour,
       endMinute,
+      hasEndDate,
     };
     await AsyncStorage.setItem(DRAFT_STORAGE_KEY, JSON.stringify(draft));
   };
@@ -490,7 +515,12 @@ export default function ModalScreen() {
   const panResponder = useRef(
     PanResponder.create({
       onMoveShouldSetPanResponder: (_, gestureState) => {
+        const isScrolledToTop = scrollOffsetRef.current <= 0;
+        const isDraggingDown = gestureState.dy > 0;
+
         return (
+          isScrolledToTop &&
+          isDraggingDown &&
           Math.abs(gestureState.dy) > 8 &&
           Math.abs(gestureState.dy) > Math.abs(gestureState.dx)
         );
@@ -594,6 +624,7 @@ export default function ModalScreen() {
   };
 
   const validateDateRange = () => {
+    if (!hasEndDate) return true;
     if (endDate < startDate) {
       Alert.alert(
         "날짜 설정 확인",
@@ -601,7 +632,6 @@ export default function ModalScreen() {
       );
       return false;
     }
-
     return true;
   };
   //저장 전 최종 검증
@@ -650,7 +680,7 @@ export default function ModalScreen() {
       repeatDays:
         repeatType === "CUSTOM" && repeatUnit === "WEEK" ? repeatDays : null,
       startDate,
-      endDate,
+      endDate: hasEndDate ? endDate : null,
     } as SaveRoutineOptions;
 
     try {
@@ -665,6 +695,21 @@ export default function ModalScreen() {
         Alert.alert("저장 실패", "루틴을 저장하지 못했어요.");
       }
     }
+  };
+  // 겹침 감지 함수
+  const isTimeConflict = (routine: ScheduleRoutine): boolean => {
+    if (!isTimed || !routine.startTime || !routine.endTime) return false;
+
+    const toMin = (h: string, m: string) => Number(h) * 60 + Number(m);
+    const [rSH, rSM] = routine.startTime.split(":");
+    const [rEH, rEM] = routine.endTime.split(":");
+
+    const newStart = toMin(startHour, startMinute);
+    const newEnd = toMin(endHour, endMinute);
+    const rStart = toMin(rSH, rSM);
+    const rEnd = toMin(rEH, rEM);
+
+    return newStart < rEnd && newEnd > rStart;
   };
   //시간 모달에서 값 적용
   const handleApplyTime = (time: {
@@ -720,8 +765,13 @@ export default function ModalScreen() {
           </View>
 
           <ScrollView
+            ref={scrollViewRef}
             showsVerticalScrollIndicator={false}
             keyboardShouldPersistTaps="handled"
+            onScroll={(e) => {
+              scrollOffsetRef.current = e.nativeEvent.contentOffset.y;
+            }}
+            scrollEventThrottle={16}
             contentContainerStyle={[
               styles.scrollContent,
               {
@@ -774,9 +824,13 @@ export default function ModalScreen() {
                 <TouchableOpacity
                   style={[
                     styles.selectorButton,
-                    activeDateField === "end" && styles.dateSelectorActive,
+                    activeDateField === "end" &&
+                      hasEndDate &&
+                      styles.dateSelectorActive,
+                    !hasEndDate && { opacity: 0.5 },
                   ]}
                   onPress={() => {
+                    if (!hasEndDate) return;
                     setActiveDateField("end");
                     setShowDatePicker((prev) =>
                       activeDateField === "end" ? !prev : true,
@@ -786,19 +840,29 @@ export default function ModalScreen() {
                   <View style={styles.selectorLeft}>
                     <IconSymbol name="calendar" size={18} color="#9FA2D6" />
                     <ThemedText style={styles.selectorText}>
-                      종료 날짜 · {formatDateLabel(endDate)}
+                      종료 날짜 ·{" "}
+                      {hasEndDate
+                        ? formatDateLabel(endDate)
+                        : "없음 (무한반복)"}
                     </ThemedText>
                   </View>
-
-                  <IconSymbol
-                    name={
-                      showDatePicker && activeDateField === "end"
-                        ? "chevron.up"
-                        : "chevron.down"
-                    }
-                    size={16}
-                    color="#A0B0D0"
-                  />
+                  <TouchableOpacity
+                    onPress={() => {
+                      setHasEndDate((prev) => !prev);
+                      setShowDatePicker(false);
+                    }}
+                    hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                  >
+                    <ThemedText
+                      style={{
+                        fontSize: 12,
+                        color: "#9FA2D6",
+                        fontWeight: "700",
+                      }}
+                    >
+                      {hasEndDate ? "종료일 해제" : "종료일 설정"}
+                    </ThemedText>
+                  </TouchableOpacity>
                 </TouchableOpacity>
               </View>
 
@@ -827,11 +891,174 @@ export default function ModalScreen() {
                 </View>
               )}
             </View>
+            {/* 이 날의 루틴 확인 */}
+            <View style={[styles.existingRoutineSection, { marginBottom: 25 }]}>
+              <TouchableOpacity
+                style={styles.existingRoutineHeader}
+                onPress={() => setShowExistingRoutines((prev) => !prev)}
+                activeOpacity={0.7}
+              >
+                <View style={styles.iconLabel}>
+                  <IconSymbol name="calendar" size={15} color="#7A87A6" />
+                  <ThemedText style={styles.existingRoutineTitle}>
+                    이 날의 루틴 확인
+                  </ThemedText>
+                </View>
+
+                <View
+                  style={{ flexDirection: "row", alignItems: "center", gap: 8 }}
+                >
+                  {/* 접혀있을 때 겹침 뱃지 표시 */}
+                  {!showExistingRoutines &&
+                    existingRoutines.some(isTimeConflict) && (
+                      <View style={styles.conflictBadge}>
+                        <ThemedText style={styles.conflictBadgeText}>
+                          겹침
+                        </ThemedText>
+                      </View>
+                    )}
+                  <ThemedText style={styles.previewDateLabel}>
+                    {formatDateLabel(previewDate)}
+                  </ThemedText>
+                  <IconSymbol
+                    name={showExistingRoutines ? "chevron.up" : "chevron.down"}
+                    size={14}
+                    color="#A0B0D0"
+                  />
+                </View>
+              </TouchableOpacity>
+
+              {showExistingRoutines && (
+                <>
+                  {/* 시작일 / 종료일 탭 */}
+                  <View style={styles.previewTabRow}>
+                    {(
+                      ["start", ...(hasEndDate ? ["end"] : [])] as (
+                        | "start"
+                        | "end"
+                      )[]
+                    ).map((field) => (
+                      <TouchableOpacity
+                        key={field}
+                        style={[
+                          styles.previewTab,
+                          previewDateField === field && styles.previewTabActive,
+                        ]}
+                        onPress={() => setPreviewDateField(field)}
+                      >
+                        <ThemedText
+                          style={[
+                            styles.previewTabText,
+                            previewDateField === field &&
+                              styles.previewTabTextActive,
+                          ]}
+                        >
+                          {field === "start" ? "시작일" : "종료일"}
+                        </ThemedText>
+                      </TouchableOpacity>
+                    ))}
+                  </View>
+
+                  {existingRoutines.length === 0 ? (
+                    <View style={styles.existingEmpty}>
+                      <ThemedText style={styles.existingEmptyText}>
+                        이 날 등록된 루틴이 없어요
+                      </ThemedText>
+                    </View>
+                  ) : (
+                    <>
+                      {existingRoutines.map((routine) => {
+                        const conflict = isTimeConflict(routine);
+                        return (
+                          <View
+                            key={routine.id}
+                            style={[
+                              styles.existingItem,
+                              conflict && styles.existingItemConflict,
+                            ]}
+                          >
+                            <View
+                              style={[
+                                styles.existingColorBar,
+                                { backgroundColor: routine.color ?? "#405886" },
+                              ]}
+                            />
+                            <View style={styles.existingInfo}>
+                              <ThemedText
+                                style={[
+                                  styles.existingName,
+                                  // 겹침이 아닐 때만 카테고리 색 적용
+                                  !conflict && {
+                                    color: routine.color ?? "#405886",
+                                  },
+                                  conflict && styles.existingNameConflict,
+                                ]}
+                              >
+                                {routine.title}
+                              </ThemedText>
+                              {routine.startTime && routine.endTime && (
+                                <ThemedText
+                                  style={[
+                                    styles.existingTime,
+                                    conflict && styles.existingTimeConflict,
+                                  ]}
+                                >
+                                  {routine.startTime.slice(0, 5)} ~{" "}
+                                  {routine.endTime.slice(0, 5)}
+                                </ThemedText>
+                              )}
+                            </View>
+                            {/* 카테고리 색상 뱃지 */}
+                            {!conflict && routine.categoryName && (
+                              <View
+                                style={[
+                                  styles.categoryChip,
+                                  {
+                                    backgroundColor:
+                                      (routine.color ?? "#405886") + "22",
+                                  },
+                                ]}
+                              >
+                                <ThemedText
+                                  style={[
+                                    styles.categoryChipText,
+                                    { color: routine.color ?? "#405886" },
+                                  ]}
+                                >
+                                  {routine.categoryName}
+                                </ThemedText>
+                              </View>
+                            )}
+                            {conflict && (
+                              <View style={styles.conflictBadge}>
+                                <ThemedText style={styles.conflictBadgeText}>
+                                  시간 겹침
+                                </ThemedText>
+                              </View>
+                            )}
+                          </View>
+                        );
+                      })}
+                      {existingRoutines.some(isTimeConflict) && (
+                        <ThemedText style={styles.conflictWarning}>
+                          ⚠ 시간이 겹치는 루틴이 있어요. 시간을 조정해 보세요.
+                        </ThemedText>
+                      )}
+                    </>
+                  )}
+                </>
+              )}
+            </View>
+
             {/* 카테고리 선택 */}
             {categoryList.length > 0 && (
               <View style={styles.section}>
                 <ThemedText style={styles.label}>카테고리</ThemedText>
-                <View style={styles.categoryGrid}>
+                <ScrollView
+                  horizontal
+                  showsHorizontalScrollIndicator={false}
+                  contentContainerStyle={{ gap: 6, paddingVertical: 2 }}
+                >
                   {categoryList.map((cat) => {
                     const resolvedColor =
                       customCategoryColorMap[cat] ?? "#405886";
@@ -872,7 +1099,7 @@ export default function ModalScreen() {
                       </TouchableOpacity>
                     );
                   })}
-                </View>
+                </ScrollView>
               </View>
             )}
             {/* 시간 / 알림 / 반복 설정 카드 */}
@@ -1842,5 +2069,130 @@ const styles = StyleSheet.create({
     fontSize: 13,
     fontWeight: "700",
     color: "#6D7690",
+  },
+  existingRoutineSection: {
+    borderRadius: 14,
+    overflow: "hidden",
+    backgroundColor: "#F8F9FB",
+  },
+  existingRoutineHeader: {
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "center",
+    padding: 12,
+    paddingHorizontal: 14,
+  },
+  existingRoutineTitle: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: "#7A87A6",
+  },
+  previewTabRow: {
+    flexDirection: "row",
+    gap: 6,
+    padding: 10,
+    paddingHorizontal: 14,
+    borderTopWidth: 1,
+    borderTopColor: "#EEF1F5",
+  },
+  previewTab: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 20,
+    borderWidth: 1,
+    borderColor: "#E4E7EE",
+    backgroundColor: "#FAFBFD",
+  },
+  previewTabActive: {
+    backgroundColor: "#EEF2FF",
+    borderColor: "#405886",
+  },
+  previewTabText: {
+    fontSize: 12,
+    fontWeight: "700",
+    color: "#6D7690",
+  },
+  previewTabTextActive: {
+    color: "#405886",
+  },
+  previewDateLabel: {
+    fontSize: 11,
+    fontWeight: "700",
+    color: "#7A87A6",
+  },
+  existingEmpty: {
+    padding: 16,
+    alignItems: "center",
+  },
+  existingEmptyText: {
+    fontSize: 12,
+    fontWeight: "600",
+    color: "#A0B0D0",
+  },
+  existingItem: {
+    flexDirection: "row",
+    alignItems: "center",
+    padding: 10,
+    paddingHorizontal: 14,
+    gap: 10,
+    borderTopWidth: 1,
+    borderTopColor: "#EEF1F5",
+  },
+  existingItemConflict: {
+    backgroundColor: "#FFF3F2",
+  },
+  existingColorBar: {
+    width: 3,
+    height: 32,
+    borderRadius: 2,
+  },
+  existingInfo: {
+    flex: 1,
+  },
+  existingName: {
+    fontSize: 13,
+    fontWeight: "700",
+    color: "#2A3C6B",
+  },
+  existingNameConflict: {
+    color: "#C0392B",
+  },
+  existingTime: {
+    fontSize: 11,
+    fontWeight: "600",
+    color: "#A0B0D0",
+    marginTop: 1,
+  },
+  existingTimeConflict: {
+    color: "#E07068",
+  },
+  conflictBadge: {
+    backgroundColor: "#FFE8E7",
+    borderRadius: 6,
+    paddingHorizontal: 7,
+    paddingVertical: 2,
+  },
+  conflictBadgeText: {
+    fontSize: 10,
+    fontWeight: "800",
+    color: "#C0392B",
+  },
+  conflictWarning: {
+    fontSize: 11,
+    fontWeight: "600",
+    color: "#E07068",
+    padding: 10,
+    paddingHorizontal: 14,
+    borderTopWidth: 1,
+    borderTopColor: "#EEF1F5",
+  },
+  categoryChip: {
+    borderRadius: 15,
+    paddingHorizontal: 7,
+    paddingVertical: 2,
+  },
+  categoryChipText: {
+    fontSize: 10,
+    fontWeight: "800",
   },
 });

--- a/components/schedule_content.tsx
+++ b/components/schedule_content.tsx
@@ -60,13 +60,16 @@ function getRepeatText(item: ScheduleRoutine) {
 }
 
 function getDateRangeText(item: ScheduleRoutine) {
-  if (item.startDate === item.endDate) {
+  if (!item.endDate || item.endDate === "" || item.endDate === item.startDate) {
+    // endDate가 없으면 무한 반복
+    if (!item.endDate || item.endDate === "") {
+      return `${item.startDate} ~ 무한 반복`;
+    }
     return item.startDate;
   }
 
   return `${item.startDate} ~ ${item.endDate}`;
 }
-
 // "HH:mm" 문자열을 시간 숫자로 바꾸는 함수
 function parseTimeString(time?: string | null) {
   if (!time) {
@@ -93,7 +96,15 @@ function isCompletedOnDate(item: ScheduleRoutine, targetDateString: string) {
   return item.completedDates?.includes(targetDateString) ?? false;
 }
 
-export default function ScheduleContent() {
+interface ScheduleContentProps {
+  onToggleComplete?: (reload: () => Promise<void>) => void;
+  onRoutineUpdated?: () => Promise<void>;
+}
+
+export default function ScheduleContent({
+  onToggleComplete,
+  onRoutineUpdated,
+}: ScheduleContentProps) {
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [noTimeRoutines, setNoTimeRoutines] = useState<ScheduleRoutine[]>([]);
@@ -185,8 +196,8 @@ export default function ScheduleContent() {
   }, [selectedDateString]);
   // 날짜가 바뀔 때마다 루틴 새로 불러오기
   useEffect(() => {
-    loadRoutines();
-  }, [loadRoutines]);
+    onToggleComplete?.(loadRoutines);
+  }, [loadRoutines, onToggleComplete]);
 
   // 다른 화면 갔다 돌아올 때 최신 데이터 불러오기
   useFocusEffect(
@@ -198,6 +209,7 @@ export default function ScheduleContent() {
     try {
       await RoutineService.toggleComplete(id, selectedDateString);
       await loadRoutines();
+      await onRoutineUpdated?.();
     } catch (error) {
       console.error("완료 상태 변경 실패", error);
     }
@@ -253,19 +265,15 @@ export default function ScheduleContent() {
             >
               {item.title}
             </Text>
-
             {isTimed && parsedStartTime && (
-              <>
-                <Text style={styles.itemTime}>
-                  {parsedEndTime
-                    ? `${String(parsedStartTime.hour).padStart(2, "0")}:${String(parsedStartTime.minute).padStart(2, "0")} ~ ${String(parsedEndTime.hour).padStart(2, "0")}:${String(parsedEndTime.minute).padStart(2, "0")}`
-                    : `${String(parsedStartTime.hour).padStart(2, "0")}:${String(parsedStartTime.minute).padStart(2, "0")}`}
-                </Text>
-
-                <Text style={styles.itemSubInfo}>{getDateRangeText(item)}</Text>
-              </>
+              <Text style={styles.itemTime}>
+                {parsedEndTime
+                  ? `${String(parsedStartTime.hour).padStart(2, "0")}:${String(parsedStartTime.minute).padStart(2, "0")} ~ ${String(parsedEndTime.hour).padStart(2, "0")}:${String(parsedEndTime.minute).padStart(2, "0")}`
+                  : `${String(parsedStartTime.hour).padStart(2, "0")}:${String(parsedStartTime.minute).padStart(2, "0")}`}
+              </Text>
             )}
 
+            <Text style={styles.itemSubInfo}>{getDateRangeText(item)}</Text>
             <Text style={styles.itemSubInfo}>{getRepeatText(item)}</Text>
           </View>
 

--- a/components/schedule_detail_modal.tsx
+++ b/components/schedule_detail_modal.tsx
@@ -2,6 +2,7 @@
 import { IconSymbol } from "@/components/ui/icon-symbol";
 import { getCategoryChipStyle, getCategoryStyle } from "@/lib/category";
 import { CategoryService } from "@/services/category_service";
+import { NotificationService } from "@/services/notification_service";
 import { RoutineService } from "@/services/routine_service";
 import type {
   RepeatType,
@@ -162,11 +163,13 @@ function formatDate(dateString: string) {
   return `${year}. ${month}. ${day}`;
 }
 
-function formatDateRange(startDate: string, endDate: string) {
+function formatDateRange(startDate: string, endDate: string | null) {
+  if (!endDate) {
+    return `${formatDate(startDate)} ~ 무한반복`;
+  }
   if (startDate === endDate) {
     return formatDate(startDate);
   }
-
   return `${formatDate(startDate)} ~ ${formatDate(endDate)}`;
 }
 
@@ -370,7 +373,7 @@ export function ScheduleDetailModal({
   const [showCustomRepeatPanel, setShowCustomRepeatPanel] = useState(false);
   const [isTimed, setIsTimed] = useState(false);
   const [isNotify, setIsNotify] = useState(false);
-
+  const [hasEndDate, setHasEndDate] = useState(true);
   const [customCategories, setCustomCategories] = useState<CustomCategory[]>(
     [],
   );
@@ -378,6 +381,9 @@ export function ScheduleDetailModal({
     const startDateParts = parseDateParts(targetRoutine.startDate);
     const endDateParts = parseDateParts(
       targetRoutine.endDate ?? targetRoutine.startDate,
+    );
+    setHasEndDate(
+      targetRoutine.endDate !== null && targetRoutine.endDate !== undefined,
     );
     const start = splitTime(targetRoutine.startTime);
     const end = splitTime(targetRoutine.endTime);
@@ -452,7 +458,7 @@ export function ScheduleDetailModal({
       categoryName,
       color: selectedColor,
       startDate: nextStartDate,
-      endDate: nextEndDate,
+      endDate: hasEndDate ? nextEndDate : null,
       startTime: isTimed ? makeTime(startHour, startMinute) : null,
       endTime: isTimed ? makeTime(endHour, endMinute) : null,
       alarm: isNotify,
@@ -487,6 +493,7 @@ export function ScheduleDetailModal({
     repeatInterval,
     repeatUnit,
     repeatDays,
+    hasEndDate,
   ]);
 
   if (!routine || !previewRoutine) return null;
@@ -538,6 +545,13 @@ export function ScheduleDetailModal({
             }
 
             await RoutineService.deleteById(routine.id);
+
+            try {
+              await NotificationService.cancelRoutineNotification(routine.id);
+            } catch (notificationError) {
+              console.warn("알림 취소 실패", notificationError);
+            }
+
             await onUpdated();
             onClose();
           } catch (error) {
@@ -631,17 +645,19 @@ export function ScheduleDetailModal({
       padNumber(safeStartMonth),
       padNumber(safeStartDay),
     );
-    const nextEndDate = makeDate(
-      String(safeEndYear),
-      padNumber(safeEndMonth),
-      padNumber(safeEndDay),
-    );
+    const nextEndDate = hasEndDate
+      ? makeDate(
+          String(safeEndYear),
+          padNumber(safeEndMonth),
+          padNumber(safeEndDay),
+        )
+      : null;
 
     if (isTimed && endTotal <= startTotal) {
       Alert.alert("안내", "종료 시간은 시작 시간보다 늦어야 해요.");
       return;
     }
-    if (nextEndDate < nextStartDate) {
+    if (hasEndDate && nextEndDate && nextEndDate < nextStartDate) {
       Alert.alert("안내", "종료 날짜는 시작 날짜보다 빠를 수 없어요.");
       return;
     }
@@ -666,8 +682,8 @@ export function ScheduleDetailModal({
         padNumber(safeEndHour),
         padNumber(safeEndMinute),
       );
-
-      await RoutineService.updateById(routine.id, {
+      const updatedRoutine: ScheduleRoutine = {
+        ...routine,
         categoryId: resolvedCategoryId,
         title: trimmedTitle,
         categoryName,
@@ -676,7 +692,7 @@ export function ScheduleDetailModal({
         endDate: nextEndDate,
         startTime: isTimed ? newStartTime : null,
         endTime: isTimed ? newEndTime : null,
-        alarm: isNotify,
+        alarm: isTimed && isNotify,
         repeatType,
         repeatInterval:
           repeatType === "CUSTOM"
@@ -688,7 +704,11 @@ export function ScheduleDetailModal({
           (repeatType === "CUSTOM" && repeatUnit === "WEEK")
             ? repeatDays
             : [],
-      });
+      };
+
+      await RoutineService.updateById(routine.id, updatedRoutine);
+
+      await NotificationService.syncRoutineNotification(updatedRoutine);
 
       setIsEditMode(false);
       onClose();
@@ -878,7 +898,15 @@ export function ScheduleDetailModal({
 
                 <View style={styles.inputBlock}>
                   <Text style={styles.editSectionLabel}>카테고리</Text>
-                  <View style={styles.categoryGrid}>
+                  <ScrollView
+                    horizontal
+                    showsHorizontalScrollIndicator={false}
+                    contentContainerStyle={{
+                      gap: 6,
+                      paddingVertical: 2,
+                      marginTop: 12,
+                    }}
+                  >
                     {categoryList.map((cat) => {
                       const chipStyle = getCategoryChipStyle(
                         cat,
@@ -915,7 +943,7 @@ export function ScheduleDetailModal({
                         </TouchableOpacity>
                       );
                     })}
-                  </View>
+                  </ScrollView>
                 </View>
 
                 <View style={styles.inputBlock}>
@@ -949,8 +977,12 @@ export function ScheduleDetailModal({
                     </TouchableOpacity>
 
                     <TouchableOpacity
-                      style={styles.dateSelectButton}
+                      style={[
+                        styles.dateSelectButton,
+                        !hasEndDate && { opacity: 0.5 },
+                      ]}
                       onPress={() => {
+                        if (!hasEndDate) return;
                         setCalendarTarget("end");
                         setShowCalendar((prev) =>
                           calendarTarget === "end" ? !prev : true,
@@ -960,19 +992,29 @@ export function ScheduleDetailModal({
                       <View style={styles.dateSelectLeft}>
                         <IconSymbol name="calendar" size={18} color="#405886" />
                         <Text style={styles.dateSelectText}>
-                          종료일 · {formatDate(selectedEndDateString)}
+                          종료일 ·{" "}
+                          {hasEndDate
+                            ? formatDate(selectedEndDateString)
+                            : "없음 (무한반복)"}
                         </Text>
                       </View>
-
-                      <IconSymbol
-                        name={
-                          showCalendar && calendarTarget === "end"
-                            ? "chevron.up"
-                            : "chevron.down"
-                        }
-                        size={16}
-                        color="#A0B0D0"
-                      />
+                      <TouchableOpacity
+                        onPress={() => {
+                          setHasEndDate((prev) => !prev);
+                          setShowCalendar(false);
+                        }}
+                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                      >
+                        <Text
+                          style={{
+                            fontSize: 12,
+                            color: "#9FA2D6",
+                            fontWeight: "700",
+                          }}
+                        >
+                          {hasEndDate ? "종료일 해제" : "종료일 설정"}
+                        </Text>
+                      </TouchableOpacity>
                     </TouchableOpacity>
                   </View>
 
@@ -1082,28 +1124,29 @@ export function ScheduleDetailModal({
                     </>
                   )}
                 </View>
+                {isTimed && (
+                  <View style={styles.inputBlock}>
+                    <View style={styles.notifyRow}>
+                      <View style={styles.notifyLabelWrap}>
+                        <IconSymbol name="bell" size={18} color="#405886" />
+                        <Text style={styles.editSectionLabelInline}>알림</Text>
+                      </View>
 
-                <View style={styles.inputBlock}>
-                  <View style={styles.notifyRow}>
-                    <View style={styles.notifyLabelWrap}>
-                      <IconSymbol name="bell" size={18} color="#405886" />
-                      <Text style={styles.editSectionLabelInline}>알림</Text>
-                    </View>
-
-                    <View style={styles.notifySwitchRow}>
-                      <Text style={styles.notifyStateText}>
-                        {isNotify ? "켜짐" : "꺼짐"}
-                      </Text>
-                      <Switch
-                        value={isNotify}
-                        onValueChange={(value) => {
-                          setIsNotify(value);
-                        }}
-                        trackColor={{ false: "#D8DEE8", true: "#9FA2D6" }}
-                      />
+                      <View style={styles.notifySwitchRow}>
+                        <Text style={styles.notifyStateText}>
+                          {isNotify ? "켜짐" : "꺼짐"}
+                        </Text>
+                        <Switch
+                          value={isNotify}
+                          onValueChange={(value) => {
+                            setIsNotify(value);
+                          }}
+                          trackColor={{ false: "#D8DEE8", true: "#9FA2D6" }}
+                        />
+                      </View>
                     </View>
                   </View>
-                </View>
+                )}
                 <View style={styles.inputBlock}>
                   <View
                     style={{

--- a/components/time_picker_modal.tsx
+++ b/components/time_picker_modal.tsx
@@ -18,6 +18,7 @@ type TimePickerModalProps = {
   startMinute: string;
   endHour: string;
   endMinute: string;
+
   onClose: () => void;
   onApply: (time: {
     startHour: string;

--- a/components/ui/_header.tsx
+++ b/components/ui/_header.tsx
@@ -6,17 +6,14 @@ import { Image, Pressable, StyleSheet, View } from "react-native";
 interface HeaderProps {
   activeTab?: "left" | "right";
 }
+const LOGO = require("@/assets/images/logo_icon.png");
 export function Header({ activeTab = "left" }: HeaderProps) {
   const router = useRouter();
   const pathname = usePathname();
   const isIndex = pathname === "/" || pathname === "/index";
   return (
     <View style={styles.header}>
-      <Image
-        source={require("@/assets/images/logo_icon.png")}
-        style={styles.logoImage}
-        resizeMode="contain"
-      />
+      <Image source={LOGO} style={styles.logoImage} resizeMode="contain" />
       <View style={styles.headerRight}>
         {isIndex && (
           <>

--- a/hooks/use_routine_form.ts
+++ b/hooks/use_routine_form.ts
@@ -1,16 +1,22 @@
 // hook/use_routine_form.ts
 import { CategoryService } from "@/services/category_service";
+import { NotificationService } from "@/services/notification_service";
 import { RoutineService } from "@/services/routine_service";
+
 import type { SaveRoutineOptions, ScheduleRoutine } from "@/types/routine";
 import { useState } from "react";
-
 export const useRoutineForm = (onSuccess: () => void) => {
   const [title, setTitle] = useState("");
   const [category, setCategory] = useState("기타");
   const [selectedColor, setSelectedColor] = useState("#405886");
-  const [selectedDate, setSelectedDate] = useState(
-    new Date().toISOString().split("T")[0],
-  );
+
+  const [selectedDate, setSelectedDate] = useState(() => {
+    const now = new Date();
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, "0");
+    const day = String(now.getDate()).padStart(2, "0");
+    return `${year}-${month}-${day}`;
+  });
   const [isTimed, setIsTimed] = useState(false);
   const [startHour, setStartHour] = useState("09");
   const [startMinute, setStartMinute] = useState("00");
@@ -22,8 +28,7 @@ export const useRoutineForm = (onSuccess: () => void) => {
     if (!title.trim()) return;
 
     const resolvedStartDate = options.startDate || selectedDate;
-    const resolvedEndDate = options.endDate || selectedDate;
-
+    const resolvedEndDate = options.endDate ?? null;
     // 서버에서 최신 카테고리 목록 조회 후 이름으로 찾기
     const serverCategories = await CategoryService.getAll();
     const matched = serverCategories.find(
@@ -60,7 +65,7 @@ export const useRoutineForm = (onSuccess: () => void) => {
       completedDates: [],
       startDate: resolvedStartDate,
       endDate: resolvedEndDate,
-      alarm: options.notifyOption !== "NONE",
+      alarm: isTimed && options.notifyOption !== "NONE",
       state: true,
       repeatType: options.repeatType,
       repeatInterval:
@@ -77,7 +82,15 @@ export const useRoutineForm = (onSuccess: () => void) => {
       }),
     };
 
-    await RoutineService.save(newRoutine);
+    const savedRoutine = await RoutineService.save(newRoutine);
+
+    if (newRoutine.alarm && newRoutine.startTime) {
+      await NotificationService.scheduleRoutineNotification({
+        ...newRoutine,
+        id: savedRoutine.id,
+      });
+    }
+
     onSuccess();
   };
 

--- a/lib/routine_mapper.ts
+++ b/lib/routine_mapper.ts
@@ -32,14 +32,14 @@ export const toScheduleRoutine = (
 export const toApiRoutineRequest = (
   routine: ScheduleRoutine,
 ): ApiRoutineRequest => {
-  if (!routine.startDate || !routine.endDate) {
-    throw new Error("startDate / endDate는 필수입니다");
+  if (!routine.startDate) {
+    throw new Error("startDate는 필수입니다");
   }
 
   return {
     categoryId: routine.categoryId ?? null,
     title: routine.title,
-    alarm: routine.alarm ?? false,
+    alarm: routine.startTime ? routine.alarm : false,
     repeatType: routine.repeatType ?? "NONE",
     repeatInterval:
       routine.repeatType === "CUSTOM" ? (routine.repeatInterval ?? 1) : null,
@@ -53,6 +53,6 @@ export const toApiRoutineRequest = (
     startTime: routine.startTime ?? null,
     endTime: routine.endTime ?? null,
     startAt: routine.startDate,
-    endAt: routine.endDate,
+    endAt: routine.endDate ?? null,
   };
 };

--- a/lib/storage.ts
+++ b/lib/storage.ts
@@ -100,11 +100,14 @@ const parseTimeToMinutes = (time: string) => {
 // 날짜 범위 겹침 여부 확인
 const isDateRangeOverlapping = (
   startA: string,
-  endA: string,
+  endA: string | null,
   startB: string,
-  endB: string,
+  endB: string | null,
 ) => {
-  return !(endA < startB || startA > endB);
+  const safeEndA = endA ?? startA;
+  const safeEndB = endB ?? startB;
+
+  return !(safeEndA < startB || startA > safeEndB);
 };
 
 // 시간 범위 겹침 여부 확인
@@ -169,7 +172,9 @@ export const shouldShowRoutineOnDate = (
   item: ScheduleRoutine,
   targetDate: string,
 ): boolean => {
-  if (targetDate < item.startDate || targetDate > item.endDate) return false;
+  const endDate = item.endDate ?? item.startDate;
+
+  if (targetDate < item.startDate || targetDate > endDate) return false;
   if (!item.repeatType || item.repeatType === "NONE") return true;
   if (item.repeatType === "DAILY") return true;
 

--- a/services/notification_service.ts
+++ b/services/notification_service.ts
@@ -1,0 +1,124 @@
+// services/notification_service.ts
+import AsyncStorage from "@react-native-async-storage/async-storage";
+import * as Notifications from "expo-notifications";
+import { Platform } from "react-native";
+
+import type { ScheduleRoutine } from "@/types/routine";
+
+const CHANNEL_ID = "routine";
+const NOTIFICATION_STORAGE_KEY = "routine_notifications";
+
+type NotificationMap = Record<string, string>;
+
+Notifications.setNotificationHandler({
+  handleNotification: async () => ({
+    shouldShowBanner: true,
+    shouldShowList: true,
+    shouldPlaySound: true,
+    shouldSetBadge: false,
+  }),
+});
+
+const getNotificationMap = async (): Promise<NotificationMap> => {
+  const value = await AsyncStorage.getItem(NOTIFICATION_STORAGE_KEY);
+  return value ? JSON.parse(value) : {};
+};
+
+const saveNotificationMap = async (map: NotificationMap) => {
+  await AsyncStorage.setItem(NOTIFICATION_STORAGE_KEY, JSON.stringify(map));
+};
+
+const getNextTriggerDate = (startTime: string) => {
+  const [hour, minute] = startTime.split(":").map(Number);
+
+  const date = new Date();
+  date.setHours(hour);
+  date.setMinutes(minute);
+  date.setSeconds(0);
+  date.setMilliseconds(0);
+
+  if (date <= new Date()) {
+    date.setDate(date.getDate() + 1);
+  }
+
+  return date;
+};
+
+export const NotificationService = {
+  requestPermission: async () => {
+    const current = await Notifications.getPermissionsAsync();
+
+    if (current.status === "granted") return true;
+
+    const requested = await Notifications.requestPermissionsAsync();
+    return requested.status === "granted";
+  },
+
+  setupAndroidChannel: async () => {
+    if (Platform.OS !== "android") return;
+
+    await Notifications.setNotificationChannelAsync(CHANNEL_ID, {
+      name: "루틴 알림",
+      importance: Notifications.AndroidImportance.HIGH,
+      sound: "default",
+      vibrationPattern: [0, 250, 250, 250],
+      lightColor: "#405886",
+    });
+  },
+
+  scheduleRoutineNotification: async (routine: ScheduleRoutine) => {
+    if (!routine.id || !routine.alarm || !routine.startTime) return null;
+
+    const hasPermission = await NotificationService.requestPermission();
+    if (!hasPermission) return null;
+
+    await NotificationService.setupAndroidChannel();
+
+    // 기존 알림이 있으면 먼저 취소
+    await NotificationService.cancelRoutineNotification(routine.id);
+
+    const triggerDate = getNextTriggerDate(routine.startTime);
+
+    const notificationId = await Notifications.scheduleNotificationAsync({
+      content: {
+        title: "루틴 시작 시간이에요",
+        body: `${routine.title} 할 시간이에요.`,
+        sound: "default",
+        data: {
+          routineId: routine.id,
+        },
+      },
+      trigger: {
+        type: Notifications.SchedulableTriggerInputTypes.DATE,
+        date: triggerDate,
+        channelId: CHANNEL_ID,
+      },
+    });
+
+    const map = await getNotificationMap();
+    map[String(routine.id)] = notificationId;
+    await saveNotificationMap(map);
+
+    return notificationId;
+  },
+
+  cancelRoutineNotification: async (routineId: number) => {
+    const map = await getNotificationMap();
+    const notificationId = map[String(routineId)];
+
+    if (!notificationId) return;
+
+    await Notifications.cancelScheduledNotificationAsync(notificationId);
+
+    delete map[String(routineId)];
+    await saveNotificationMap(map);
+  },
+  syncRoutineNotification: async (routine: ScheduleRoutine) => {
+    if (routine.alarm && routine.startTime) {
+      await NotificationService.scheduleRoutineNotification(routine);
+      return;
+    }
+
+    await NotificationService.cancelRoutineNotification(routine.id);
+  },
+};

--- a/services/routine_service.ts
+++ b/services/routine_service.ts
@@ -42,11 +42,10 @@ export const RoutineService = {
   },
 
   // 루틴 생성
-  save: async (routine: ScheduleRoutine): Promise<void> => {
-    const body = toApiRoutineRequest(routine);
-    await api("/routines", {
+  save: async (routine: ScheduleRoutine) => {
+    return api("/routines", {
       method: "POST",
-      body: JSON.stringify(body),
+      body: JSON.stringify(toApiRoutineRequest(routine)),
     });
   },
 

--- a/types/routine.ts
+++ b/types/routine.ts
@@ -22,7 +22,7 @@ export interface ScheduleRoutine {
   categoryName?: string;
   color?: string;
   startDate: string;
-  endDate: string;
+  endDate: string | null;
   startTime?: string | null;
   endTime?: string | null;
   alarm: boolean;
@@ -55,7 +55,7 @@ export interface SaveRoutineOptions {
   repeatDays: RepeatWeekday[] | null;
 
   startDate: string;
-  endDate: string;
+  endDate: string | null;
 }
 
 // 시간 선택 모달에서 사용하는 시간 범위 타입
@@ -95,8 +95,8 @@ export interface ApiRoutineRequest {
   repeatDays: RepeatWeekday[] | null;
   startTime: string | null;
   endTime: string | null;
-  startAt: string; // 로컬의 startDate
-  endAt: string; // 로컬의 endDate
+  startAt: string;
+  endAt: string | null;
 }
 export interface RoutineCategory {
   id: number;
@@ -113,6 +113,9 @@ export interface CategoryRequest {
 export interface HeatmapRoutine {
   routineId: number;
   title: string;
+  startAt: string;
+  endAt: string | null;
+
   category: {
     id: number;
     name: string;


### PR DESCRIPTION
## 관련 이슈

- Closes #73 

---

## 작업 내용

1. 무한반복 루틴
- 종료일 없는 루틴 지원
- hasEndDate 상태 추가 및 draft 저장/복원 처리. 종료일 해제/설정 토글 버튼 UI 추가 (추가·수정 모달). 종료일 없음 선택 시 endDate: null 저장 및 백엔드에 endAt: null 전송.
- SaveRoutineOptions, ApiRoutineRequest, ScheduleRoutine 타입 endDate/endAt null 허용. routine_mapper.ts startDate만 필수 체크, endAt: routine.endDate ?? null 처리. use_routine_form.ts resolvedEndDate = options.endDate ?? null 처리.
- 상세 모달 읽기 모드에서 무한반복 날짜 표시: 시작일 ~ 무한반복. 목록에서 시간 없는 루틴에도 날짜 범위 표시. 카테고리 목록 View → 가로 ScrollView 교체.

2. 로컬 알림
- 루틴 로컬 알림 기능 및 자동 복구
- expo-notifications 기반 NotificationService 추가. 루틴 생성 시 알림 예약, 수정 시 취소 후 재예약, 삭제 시 취소. notificationId AsyncStorage 저장으로 루틴별 알림 관리. 시간 없는 루틴은 alarm 조건 처리로 예약 불가.
- use_routine_form, schedule_detail_modal에 알림 동기화 로직 연결. 앱 시작 및 로그인 복구 시 alarm=true && startTime 존재하는 루틴 자동 재예약 (_layout.tsx). isLoggedIn 기반 보호 처리.

3. 통계
- 루틴 유효 기간 필터링
- 기존: groupedRoutines useMemo에서 루틴 유효 기간 비교 없이 모든 달에 표시되는 문제.

- 수정: 선택 뷰모드(년/월/주)에 따라 기간 계산 후 startAt~endAt이 겹치는 루틴만 필터링. 겹침 조건: 루틴시작 ≤ 선택기간끝 && 루틴종료 ≥ 선택기간시작. endAt=null이면 먼 미래로 처리하여 항상 표시. viewMode, selectedYear, selectedMonth, selectedWeekDate 의존성 배열 추가. HeatmapRoutine 타입에 startAt, endAt 필드 추가.

4. 루틴 겹침 확인 UI
- 루틴 추가 모달 — 기존 루틴 확인 섹션
- 날짜 선택 섹션 아래 "이 날의 루틴 확인" 접기/펼치기 섹션 추가. 시작일/종료일 탭 전환으로 각 날짜의 기존 루틴 목록 확인 가능.

- 시간 설정 ON 상태에서 시간이 겹치는 루틴을 빨간색으로 강조 표시 및 "시간 겹침" 뱃지 노출. 겹치는 루틴 감지 시 섹션 자동 펼침. 접힌 상태에서도 헤더 뱃지로 겹침 여부 표시. 카테고리 색상을 루틴 제목 및 뱃지에 반영.

5. UI 개선
- 목록 화면 표시 개선
- 시간 없는 루틴 목록 카드에 날짜 범위 표시. 무한반복 루틴 목록 카드: 시작일 ~ 형식. 카테고리 목록 가로 스크롤 적용.

６. 로고
- 컴포넌트 리마운트 시 require 재실행 타이밍 문제
- require()가 컴포넌트 함수 내부에 있으면, 로그아웃 → 로그인으로 컴포넌트가 리마운트될 때 React Native 번들러가 이미지 모듈을 다시 resolve하는 타이밍에 일시적으로 undefined를 반환하는 경우가 있음. 결과적으로 로그인 직후 로고가 잠깐 또는 영구적으로 사라지는 현상 발생.
- require()를 컴포넌트 내부에서 모듈 최상단으로 이동

---

## 테스트 체크리스트

- 무한반복 루틴
- [x] 종료일 해제/설정 토글 → 버튼 상태 전환
- [x] 종료일 없음 저장 → endAt: null 전송 확인
- [x] 수정 모달 진입 및 저장 → 정상 동작
로컬 알림
- [x] 생성/수정/삭제 시 알림 예약·취소 동작
- 통계
- [x] 선택 기간 밖 루틴 → 미표시
- [x] 무한반복 루틴(endAt=null) → 항상 표시

- 루틴 겹침 확인 UI
- [x] 시간 겹침 → 빨간색 강조 및 뱃지 노출
- [x] 카테고리 색상 루틴 제목·뱃지에 반영
- UI
- [x] 시간 없는 루틴 카드에 날짜 범위 표시
- [x] 무한반복 루틴 카드 → 시작일 ~ 형식
- [x] 카테고리 많을 때 가로 스크롤 동작

---

## 참고사항

-
