### PR TITLE
fix: 타임테이블 04:00 기준 표시 및 자정 넘김 루틴 렌더링 처리

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -61,8 +61,9 @@ function buildTimetableEvents(routines: ScheduleRoutine[]): TimetableEvent[] {
   routines.forEach((routine) => {
     if (!routine.startTime || !routine.endTime) return;
     const startMinute = parseTimeToMinutes(routine.startTime);
-    const endMinute = parseTimeToMinutes(routine.endTime);
+    let endMinute = parseTimeToMinutes(routine.endTime);
     if (startMinute === null || endMinute === null) return;
+    if (endMinute < startMinute) endMinute += 1440;
     if (endMinute <= startMinute) return;
     events.push({
       id: String(routine.id),
@@ -98,8 +99,8 @@ export default function HomeScreen() {
   const [storedRoutines, setStoredRoutines] = useState<ScheduleRoutine[]>([]);
   const scheduleReloadRef = useRef<(() => Promise<void>) | null>(null);
 
-  const startHour = 0;
-  const endHour = 24;
+  const startHour = 4;
+  const endHour = 28;
   const hourHeight = 60;
   const hours = Array.from(
     { length: endHour - startHour },
@@ -148,7 +149,9 @@ export default function HomeScreen() {
 
   useEffect(() => {
     const currentHour = new Date().getHours();
-    const yOffset = Math.max(0, (currentHour - startHour - 1) * hourHeight);
+    const adjustedHour =
+      currentHour < startHour ? currentHour + 24 : currentHour;
+    const yOffset = Math.max(0, (adjustedHour - startHour - 1) * hourHeight);
     const timeout = setTimeout(() => {
       timetableScrollRef.current?.scrollTo({ y: yOffset, animated: true });
     }, 100);
@@ -335,12 +338,17 @@ export default function HomeScreen() {
                   {/* 시간 축 */}
                   <View style={styles.timeAxis}>
                     {hours.map((hour) => {
+                      const displayHour = hour % 24;
+                      const adjustedCurrentHour =
+                        currentTime.getHours() < startHour
+                          ? currentTime.getHours() + 24
+                          : currentTime.getHours();
                       const isCurrentHour =
                         isSameDay(currentDate, new Date()) &&
-                        hour === currentTime.getHours();
+                        hour === adjustedCurrentHour;
                       const label = isCurrentHour
                         ? `${String(currentTime.getHours()).padStart(2, "0")}:${String(currentTime.getMinutes()).padStart(2, "0")}`
-                        : String(hour);
+                        : String(displayHour);
                       return (
                         <View
                           key={hour}
@@ -442,6 +450,10 @@ export default function HomeScreen() {
                     {isSameDay(currentDate, new Date()) &&
                       (() => {
                         const currentHour = currentTime.getHours();
+                        const adjustedHour =
+                          currentHour < startHour
+                            ? currentHour + 24
+                            : currentHour;
                         const currentMinute = currentTime.getMinutes();
                         const leftPercent = (currentMinute / 60) * 100;
 
@@ -452,7 +464,7 @@ export default function HomeScreen() {
                               styles.currentTimeIndicator,
                               {
                                 left: `${leftPercent}%`,
-                                top: (currentHour - startHour) * hourHeight,
+                                top: (adjustedHour - startHour) * hourHeight,
                                 height: hourHeight,
                               },
                             ]}


### PR DESCRIPTION
## 관련 이슈

- Closes #77 

---

## 작업 내용

- 타임테이블 표시 기준을 00:00~24:00 → 04:00~익일 04:00으로 변경
- 자정을 넘기는 루틴(endTime < startTime)의 endMinute에 +1440 처리하여 올바른 위치에 렌더링
- 시간 라벨을 % 24 처리하여 24, 25, 26, 27 → 0, 1, 2, 3으로 표시
- 현재 시간 인디케이터 및 초기 스크롤 위치 계산에 자정 이후 시간 보정 적용

---

## 테스트 체크리스트

- [x] 예시

---

## 참고사항

-
