### PR TITLE
design: 카테고리 및 루틴 UI/UX 개선

### DIFF
--- a/app/(tabs)/category.tsx
+++ b/app/(tabs)/category.tsx
@@ -1,5 +1,6 @@
 //category.tsx
 import { DraggableCategoryList } from "@/components/DraggableCategoryList";
+import { ScheduleDetailModal } from "@/components/schedule_detail_modal";
 import { Header } from "@/components/ui/_header";
 import {
   getCategoryBadgeStyle,
@@ -16,7 +17,6 @@ import type { ScheduleRoutine } from "@/types/routine";
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { useFocusEffect, useRouter } from "expo-router";
 import React, { useCallback, useMemo, useRef, useState } from "react";
-
 import {
   ActivityIndicator,
   Alert,
@@ -240,7 +240,9 @@ export default function CategoryScreen() {
   const [serverCategoryIdMap, setServerCategoryIdMap] = useState<
     Record<string, number>
   >({});
-
+  const [selectedRoutine, setSelectedRoutine] =
+    useState<ScheduleRoutine | null>(null);
+  const [isDetailModalVisible, setIsDetailModalVisible] = useState(false);
   const categoryModalTranslateY = useRef(new Animated.Value(0)).current;
   const CATEGORY_MODAL_CLOSE_THRESHOLD = 120;
 
@@ -854,13 +856,18 @@ export default function CategoryScreen() {
     const completed = isRoutineCompleted(routine);
 
     return (
-      <View key={routine.id} style={styles.routineItem}>
+      <Pressable
+        key={routine.id}
+        style={styles.routineItem}
+        onPress={() => {
+          setSelectedRoutine(routine);
+          setIsDetailModalVisible(true);
+        }}
+      >
         <View
           style={[
             styles.routineDot,
-            completed && {
-              backgroundColor: routine.color ?? DEFAULT_COLOR,
-            },
+            completed && { backgroundColor: routine.color ?? DEFAULT_COLOR },
           ]}
         />
         <View style={styles.routineTextWrapper}>
@@ -876,7 +883,7 @@ export default function CategoryScreen() {
             {routine.startDate} ~ {routine.endDate}
           </Text>
         </View>
-      </View>
+      </Pressable>
     );
   };
   // 카테고리 카드 한 개를 렌더링
@@ -911,7 +918,7 @@ export default function CategoryScreen() {
           <View style={styles.routineBox}>
             <View style={styles.routineContentBox}>
               {item.routines.length > 0 ? (
-                item.routines.slice(0, 3).map(renderRoutineItem)
+                item.routines.map(renderRoutineItem)
               ) : (
                 <Text style={styles.emptyRoutineText}>
                   {selectedTab === "ACTIVE"
@@ -1196,7 +1203,7 @@ export default function CategoryScreen() {
                             <Text
                               style={[
                                 styles.categoryBadgeText,
-                                { color: badgeStyle.textColor },
+                                { color: "#233255" },
                               ]}
                             >
                               {item.name}
@@ -1289,9 +1296,20 @@ export default function CategoryScreen() {
                           { backgroundColor: pickerColor },
                         ]}
                       />
-                      <Text style={styles.selectedColorHexText}>
-                        {pickerColor.toUpperCase()}
-                      </Text>
+                      <TextInput
+                        style={styles.selectedColorHexInput}
+                        value={pickerColor.toUpperCase()}
+                        onChangeText={(text) => {
+                          const cleaned = text.startsWith("#")
+                            ? text
+                            : `#${text}`;
+                          setPickerColor(cleaned);
+                        }}
+                        maxLength={7}
+                        autoCapitalize="characters"
+                        placeholder="#000000"
+                        placeholderTextColor="#9CA3AF"
+                      />
                     </View>
                   </View>
                 )}
@@ -1324,6 +1342,15 @@ export default function CategoryScreen() {
           </KeyboardAvoidingView>
         </Modal>
       </View>
+      <ScheduleDetailModal
+        visible={isDetailModalVisible}
+        routine={selectedRoutine}
+        onClose={() => {
+          setIsDetailModalVisible(false);
+          setSelectedRoutine(null);
+        }}
+        onUpdated={refreshData}
+      />
     </SafeAreaView>
   );
 }
@@ -1919,5 +1946,15 @@ const styles = StyleSheet.create({
     fontWeight: "700",
     color: "#405886",
     lineHeight: 20,
+  },
+  selectedColorHexInput: {
+    fontSize: 14,
+    fontWeight: "700",
+    color: "#405886",
+    borderBottomWidth: 1,
+    borderBottomColor: "#D7DEEA",
+    paddingVertical: 2,
+    minWidth: 80,
+    textAlign: "center",
   },
 });

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -347,7 +347,7 @@ export default function HomeScreen() {
                       markedDates={calendarMarkedDates}
                       onDayPress={(day) => {
                         setCurrentDate(new Date(day.timestamp));
-                        setIsCalendarVisible(false);
+                        // setIsCalendarVisible(false);
                       }}
                     />
                   </View>
@@ -459,7 +459,7 @@ export default function HomeScreen() {
                                 <Text
                                   style={[
                                     styles.eventTitle,
-                                    { color: typeStyles.text },
+                                    { color: "#233255" },
                                   ]}
                                   numberOfLines={1}
                                 >

--- a/components/schedule_content.tsx
+++ b/components/schedule_content.tsx
@@ -236,24 +236,35 @@ export default function ScheduleContent({
     return (
       <TouchableOpacity
         activeOpacity={0.8}
-        onPress={() => {
-          handlePressRoutine(item);
-        }}
+        onPress={() => handlePressRoutine(item)}
       >
         <View style={styles.itemRow}>
           <View
-            style={[
-              styles.tagBadge,
-              {
-                backgroundColor: typeStyle.bg,
-                borderColor: typeStyle.dot,
-                marginRight: 14,
-              },
-            ]}
+            style={{
+              width: 80,
+              marginRight: 10,
+              flexShrink: 0,
+              justifyContent: "center",
+              alignItems: "center",
+            }}
           >
-            <Text style={[styles.tagText, { color: typeStyle.text }]}>
-              {typeLabel}
-            </Text>
+            <View
+              style={[
+                styles.tagBadge,
+                {
+                  backgroundColor: typeStyle.bg,
+                  borderColor: typeStyle.dot,
+                  alignSelf: "stretch",
+                },
+              ]}
+            >
+              <Text
+                style={[styles.tagText, { color: "#233255" }]}
+                numberOfLines={1}
+              >
+                {typeLabel}
+              </Text>
+            </View>
           </View>
 
           <View style={styles.itemContent}>
@@ -531,7 +542,7 @@ const styles = StyleSheet.create({
   },
   itemContent: {
     flex: 1,
-    marginLeft: 14,
+    marginLeft: 0,
   },
   itemTitle: {
     fontSize: 16,
@@ -553,13 +564,14 @@ const styles = StyleSheet.create({
     marginTop: 2,
   },
   tagBadge: {
-    paddingHorizontal: 10,
+    paddingHorizontal: 7,
     paddingVertical: 4,
     borderRadius: 8,
   },
   tagText: {
     fontSize: 12,
     fontWeight: "700",
+    textAlign: "center",
   },
   divider: {
     height: 1,

--- a/components/schedule_detail_modal.tsx
+++ b/components/schedule_detail_modal.tsx
@@ -4,6 +4,8 @@ import { getCategoryChipStyle, getCategoryStyle } from "@/lib/category";
 import { CategoryService } from "@/services/category_service";
 import { NotificationService } from "@/services/notification_service";
 import { RoutineService } from "@/services/routine_service";
+
+import TimePickerModal from "@/components/time_picker_modal";
 import type {
   RepeatType,
   RepeatUnit,
@@ -223,130 +225,10 @@ function getDaysInMonth(year: number, month: number) {
   return new Date(year, month, 0).getDate();
 }
 
-function getNextHour(hour: string) {
-  return padNumber((Number(hour) + 1) % 24);
-}
-
-function getPrevHour(hour: string) {
-  return padNumber((Number(hour) - 1 + 24) % 24);
-}
-
-function getNextMinute(minute: string) {
-  const currentIndex = MINUTE_OPTIONS.indexOf(minute);
-  const safeIndex = currentIndex >= 0 ? currentIndex : 0;
-  const nextIndex = (safeIndex + 1) % MINUTE_OPTIONS.length;
-  return MINUTE_OPTIONS[nextIndex];
-}
-
-function getPrevMinute(minute: string) {
-  const currentIndex = MINUTE_OPTIONS.indexOf(minute);
-  const safeIndex = currentIndex >= 0 ? currentIndex : 0;
-  const prevIndex =
-    (safeIndex - 1 + MINUTE_OPTIONS.length) % MINUTE_OPTIONS.length;
-  return MINUTE_OPTIONS[prevIndex];
-}
-
 function normalizeMinuteOption(minute: string) {
   return MINUTE_OPTIONS.includes(minute) ? minute : "00";
 }
 
-function TimeStepperControl({
-  label,
-  value,
-  onIncrease,
-  onDecrease,
-  onChange,
-  onInputFocus,
-}: {
-  label: string;
-  value: string;
-  onIncrease: () => void;
-  onDecrease: () => void;
-  onChange?: (value: string) => void;
-  onInputFocus?: () => void;
-}) {
-  const [inputValue, setInputValue] = useState(value);
-  const [isFocused, setIsFocused] = useState(false);
-
-  useEffect(() => {
-    if (!isFocused) {
-      setInputValue(value);
-    }
-  }, [value, isFocused]);
-
-  const handleChangeText = (text: string) => {
-    const cleaned = text.replace(/[^0-9]/g, "").slice(0, 2);
-    setInputValue(cleaned);
-
-    if (Platform.OS === "android" && cleaned.length === 2) {
-      const num = Number(cleaned);
-      const safeHour = padNumber(clamp(num, 0, 23));
-      setInputValue(safeHour);
-      onChange?.(safeHour);
-      Keyboard.dismiss();
-    }
-  };
-
-  const handleBlur = () => {
-    setIsFocused(false);
-
-    if (!onChange || inputValue === "") {
-      setInputValue(value);
-      return;
-    }
-
-    const num = Number(inputValue);
-    if (Number.isNaN(num)) {
-      setInputValue(value);
-      return;
-    }
-
-    const safeHour = padNumber(clamp(num, 0, 23));
-    setInputValue(safeHour);
-    onChange(safeHour);
-  };
-
-  return (
-    <View style={styles.timeStepperBox}>
-      <Text style={styles.timeStepperLabel}>{label}</Text>
-
-      <View style={styles.timeStepperRow}>
-        <TouchableOpacity style={styles.timeStepperButton} onPress={onDecrease}>
-          <Text style={styles.timeStepperButtonText}>-</Text>
-        </TouchableOpacity>
-
-        {onChange ? (
-          <TextInput
-            style={styles.timeStepperValueInput}
-            value={inputValue}
-            onChangeText={handleChangeText}
-            onFocus={() => {
-              setIsFocused(true);
-              setInputValue("");
-              onInputFocus?.();
-            }}
-            onBlur={handleBlur}
-            keyboardType="number-pad"
-            maxLength={2}
-            returnKeyType="done"
-            blurOnSubmit
-            onSubmitEditing={() => {
-              Keyboard.dismiss();
-            }}
-          />
-        ) : (
-          <View style={styles.timeStepperValueBox}>
-            <Text style={styles.timeStepperValueText}>{value}</Text>
-          </View>
-        )}
-
-        <TouchableOpacity style={styles.timeStepperButton} onPress={onIncrease}>
-          <Text style={styles.timeStepperButtonText}>+</Text>
-        </TouchableOpacity>
-      </View>
-    </View>
-  );
-}
 export function ScheduleDetailModal({
   visible,
   routine,
@@ -464,6 +346,7 @@ export function ScheduleDetailModal({
   const [repeatDays, setRepeatDays] = useState<RepeatWeekday[]>([]);
   const [showRepeatPanel, setShowRepeatPanel] = useState(false);
   const [showCustomRepeatPanel, setShowCustomRepeatPanel] = useState(false);
+  const [showTimeModal, setShowTimeModal] = useState(false);
   const [isTimed, setIsTimed] = useState(false);
   const [isNotify, setIsNotify] = useState(false);
   const [hasEndDate, setHasEndDate] = useState(true);
@@ -716,6 +599,26 @@ export function ScheduleDetailModal({
     setRepeatType("CUSTOM");
     setShowCustomRepeatPanel(false);
   };
+  const handleApplyTime = (time: {
+    startHour: string;
+    startMinute: string;
+    endHour: string;
+    endMinute: string;
+  }) => {
+    const startTotal = Number(time.startHour) * 60 + Number(time.startMinute);
+    const endTotal = Number(time.endHour) * 60 + Number(time.endMinute);
+
+    if (endTotal <= startTotal) {
+      Alert.alert("시간 설정 확인", "끝나는 시간은 시작 시간보다 늦어야 해요.");
+      return;
+    }
+
+    setStartHour(time.startHour);
+    setStartMinute(time.startMinute);
+    setEndHour(time.endHour);
+    setEndMinute(time.endMinute);
+    setShowTimeModal(false);
+  };
   const handleSave = async () => {
     if (isSaving) return;
     if (!routine) return;
@@ -830,771 +733,751 @@ export function ScheduleDetailModal({
     }
   };
   return (
-    <Modal visible={visible} transparent animationType="none">
-      <View style={styles.modalRoot}>
-        <Pressable style={styles.detailOverlay} onPress={closeWithAnimation} />
+    <>
+      <Modal visible={visible} transparent animationType="none">
+        <View style={styles.modalRoot}>
+          <Pressable
+            style={styles.detailOverlay}
+            onPress={closeWithAnimation}
+          />
 
-        <Animated.View
-          style={{
-            transform: [
-              {
-                translateY: Animated.add(slideAnim, dragY),
-              },
-            ],
-          }}
-        >
-          <View
-            style={[
-              styles.detailCard,
-              {
-                paddingBottom: 100,
-                marginBottom: -100,
-              },
-            ]}
+          <Animated.View
+            style={{
+              transform: [
+                {
+                  translateY: Animated.add(slideAnim, dragY),
+                },
+              ],
+            }}
           >
-            <View style={styles.dragHandleArea} {...panResponder.panHandlers}>
-              <View style={styles.dragHandle} />
-            </View>
-
-            <View style={styles.detailHeader}>
-              <Text style={styles.detailTitle}>
-                {isEditMode ? "루틴 수정" : "상세 정보"}
-              </Text>
-              <View style={styles.headerActions}>
-                {!isEditMode ? (
-                  <>
-                    {/* readOnly가 아닐 때만 수정/삭제 버튼 표시 */}
-                    {!readOnly && (
-                      <>
-                        <TouchableOpacity
-                          onPress={handleEdit}
-                          style={styles.editIconButton}
-                        >
-                          <Ionicons
-                            name="pencil-outline"
-                            size={18}
-                            color="#405886"
-                          />
-                        </TouchableOpacity>
-
-                        <TouchableOpacity
-                          onPress={handleDelete}
-                          style={styles.deleteIconButton}
-                        >
-                          <Ionicons
-                            name="trash-outline"
-                            size={18}
-                            color="#D45A68"
-                          />
-                        </TouchableOpacity>
-                      </>
-                    )}
-
-                    <TouchableOpacity onPress={closeWithAnimation}>
-                      <IconSymbol name="xmark" size={20} color="#B4B6C0" />
-                    </TouchableOpacity>
-                  </>
-                ) : (
-                  <>
-                    <TouchableOpacity
-                      onPress={handleCancelEdit}
-                      style={styles.editButton}
-                    >
-                      <Text style={styles.cancelText}>취소</Text>
-                    </TouchableOpacity>
-                    <TouchableOpacity
-                      onPress={() => {
-                        if (!isSaving) handleSave();
-                      }}
-                      style={[styles.saveButton, isSaving && { opacity: 0.5 }]}
-                      disabled={isSaving}
-                    >
-                      <Text style={styles.saveText}>
-                        {isSaving ? "저장 중" : "저장"}
-                      </Text>
-                    </TouchableOpacity>
-                  </>
-                )}
+            <View
+              style={[
+                styles.detailCard,
+                {
+                  paddingBottom: 100,
+                  marginBottom: -100,
+                },
+              ]}
+            >
+              <View style={styles.dragHandleArea} {...panResponder.panHandlers}>
+                <View style={styles.dragHandle} />
               </View>
-            </View>
-            {!isEditMode ? (
-              <>
-                <View style={styles.titleRow}>
-                  <Text style={styles.detailRoutineTitle} numberOfLines={2}>
-                    {previewRoutine.title}
-                  </Text>
 
-                  <View
-                    style={[
-                      styles.tagBadge,
-                      { backgroundColor: categoryStyle.bg },
-                    ]}
-                  >
-                    <Text
-                      style={[styles.tagText, { color: categoryStyle.text }]}
-                    >
-                      {previewRoutine.categoryName ?? "카테고리 없음"}{" "}
-                    </Text>
-                  </View>
-                </View>
-
-                <View style={styles.infoList}>
-                  <View style={styles.detailInfoRow}>
-                    <IconSymbol name="calendar" size={18} color="#A0B0D0" />
-                    <View style={styles.infoTextGroup}>
-                      <Text style={styles.detailLabel}>날짜</Text>
-                      <Text style={styles.detailValue}>
-                        {formatDateRange(
-                          previewRoutine.startDate,
-                          previewRoutine.endDate,
-                        )}
-                      </Text>
-                    </View>
-                  </View>
-
-                  <View style={styles.detailInfoRow}>
-                    <IconSymbol name="clock" size={18} color="#A0B0D0" />
-                    <View style={styles.infoTextGroup}>
-                      <Text style={styles.detailLabel}>시간</Text>
-                      <Text style={styles.detailValue}>
-                        {formatTimeRange(
-                          previewRoutine.startTime,
-                          previewRoutine.endTime,
-                        )}
-                      </Text>
-                    </View>
-                  </View>
-
-                  <View style={styles.detailInfoRow}>
-                    <IconSymbol name="bell" size={18} color="#A0B0D0" />
-                    <View style={styles.infoTextGroup}>
-                      <Text style={styles.detailLabel}>알림</Text>
-                      <Text style={styles.detailValue}>
-                        {getNotifyText(previewRoutine)}
-                      </Text>
-                    </View>
-                  </View>
-
-                  <View style={styles.detailInfoRow}>
-                    <IconSymbol name="repeat" size={18} color="#A0B0D0" />
-                    <View style={styles.infoTextGroup}>
-                      <Text style={styles.detailLabel}>반복 설정</Text>
-                      <Text style={styles.detailValue}>
-                        {getRepeatText(previewRoutine)}
-                      </Text>
-                    </View>
-                  </View>
-                </View>
-              </>
-            ) : (
-              <ScrollView
-                ref={editScrollRef}
-                style={styles.editScroll}
-                contentContainerStyle={styles.editScrollContent}
-                showsVerticalScrollIndicator={false}
-                nestedScrollEnabled
-                keyboardShouldPersistTaps="always"
-                keyboardDismissMode="on-drag"
-              >
-                <View style={styles.inputBlock}>
-                  <Text style={styles.editSectionLabel}>제목</Text>
-                  <TextInput
-                    value={title}
-                    onChangeText={setTitle}
-                    placeholder="루틴 제목을 입력해 주세요"
-                    placeholderTextColor="#B4B6C0"
-                    style={styles.titleInput}
-                  />
-                </View>
-
-                <View style={styles.inputBlock}>
-                  <Text style={styles.editSectionLabel}>카테고리</Text>
-                  <ScrollView
-                    horizontal
-                    showsHorizontalScrollIndicator={false}
-                    contentContainerStyle={{
-                      gap: 6,
-                      paddingVertical: 2,
-                      marginTop: 12,
-                    }}
-                  >
-                    {categoryList.map((cat) => {
-                      const chipStyle = getCategoryChipStyle(
-                        cat,
-                        customCategoryColorMap,
-                      );
-                      const isSelected = categoryName === cat;
-
-                      return (
-                        <TouchableOpacity
-                          key={cat}
-                          style={[
-                            styles.categoryChip,
-                            {
-                              backgroundColor: chipStyle.bg,
-                              borderColor: isSelected
-                                ? chipStyle.dot
-                                : "transparent",
-                              borderWidth: isSelected ? 1.5 : 1,
-                            },
-                          ]}
-                          onPress={() => {
-                            setCategoryName(cat);
-                            setSelectedColor(chipStyle.dot);
-                          }}
-                        >
-                          <Text
-                            style={[
-                              styles.categoryChipText,
-                              { color: chipStyle.text },
-                            ]}
+              <View style={styles.detailHeader}>
+                <Text style={styles.detailTitle}>
+                  {isEditMode ? "루틴 수정" : "상세 정보"}
+                </Text>
+                <View style={styles.headerActions}>
+                  {!isEditMode ? (
+                    <>
+                      {/* readOnly가 아닐 때만 수정/삭제 버튼 표시 */}
+                      {!readOnly && (
+                        <>
+                          <TouchableOpacity
+                            onPress={handleEdit}
+                            style={styles.editIconButton}
                           >
-                            {cat}
-                          </Text>
-                        </TouchableOpacity>
-                      );
-                    })}
-                  </ScrollView>
-                </View>
+                            <Ionicons
+                              name="pencil-outline"
+                              size={18}
+                              color="#405886"
+                            />
+                          </TouchableOpacity>
 
-                <View style={styles.inputBlock}>
-                  <Text style={styles.editSectionLabel}>날짜</Text>
-                  <View style={styles.dateRangeBlock}>
-                    <TouchableOpacity
-                      style={styles.dateSelectButton}
-                      onPress={() => {
-                        setCalendarTarget("start");
-                        setShowCalendar((prev) =>
-                          calendarTarget === "start" ? !prev : true,
-                        );
-                      }}
-                    >
-                      <View style={styles.dateSelectLeft}>
-                        <IconSymbol name="calendar" size={18} color="#405886" />
-                        <Text style={styles.dateSelectText}>
-                          시작일 · {formatDate(selectedStartDateString)}
-                        </Text>
-                      </View>
+                          <TouchableOpacity
+                            onPress={handleDelete}
+                            style={styles.deleteIconButton}
+                          >
+                            <Ionicons
+                              name="trash-outline"
+                              size={18}
+                              color="#D45A68"
+                            />
+                          </TouchableOpacity>
+                        </>
+                      )}
 
-                      <IconSymbol
-                        name={
-                          showCalendar && calendarTarget === "start"
-                            ? "chevron.up"
-                            : "chevron.down"
-                        }
-                        size={16}
-                        color="#A0B0D0"
-                      />
-                    </TouchableOpacity>
-
-                    <TouchableOpacity
-                      style={[
-                        styles.dateSelectButton,
-                        !hasEndDate && { opacity: 0.5 },
-                      ]}
-                      onPress={() => {
-                        if (!hasEndDate) return;
-                        setCalendarTarget("end");
-                        setShowCalendar((prev) =>
-                          calendarTarget === "end" ? !prev : true,
-                        );
-                      }}
-                    >
-                      <View style={styles.dateSelectLeft}>
-                        <IconSymbol name="calendar" size={18} color="#405886" />
-                        <Text style={styles.dateSelectText}>
-                          종료일 ·{" "}
-                          {hasEndDate
-                            ? formatDate(selectedEndDateString)
-                            : "없음 (무한반복)"}
-                        </Text>
-                      </View>
+                      <TouchableOpacity onPress={closeWithAnimation}>
+                        <IconSymbol name="xmark" size={20} color="#B4B6C0" />
+                      </TouchableOpacity>
+                    </>
+                  ) : (
+                    <>
+                      <TouchableOpacity
+                        onPress={handleCancelEdit}
+                        style={styles.editButton}
+                      >
+                        <Text style={styles.cancelText}>취소</Text>
+                      </TouchableOpacity>
                       <TouchableOpacity
                         onPress={() => {
-                          setHasEndDate((prev) => !prev);
-                          setShowCalendar(false);
+                          if (!isSaving) handleSave();
                         }}
-                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                        style={[
+                          styles.saveButton,
+                          isSaving && { opacity: 0.5 },
+                        ]}
+                        disabled={isSaving}
                       >
-                        <Text
-                          style={{
-                            fontSize: 12,
-                            color: "#9FA2D6",
-                            fontWeight: "700",
-                          }}
-                        >
-                          {hasEndDate ? "종료일 해제" : "종료일 설정"}
+                        <Text style={styles.saveText}>
+                          {isSaving ? "저장 중" : "저장"}
                         </Text>
                       </TouchableOpacity>
-                    </TouchableOpacity>
-                  </View>
-
-                  {showCalendar && (
-                    <View style={styles.calendarContainer}>
-                      <AppCalendar
-                        current={selectedCalendarDateString}
-                        markedDates={{
-                          [selectedCalendarDateString]: {
-                            selected: true,
-                            selectedColor: "#F1F1FB",
-                          },
-                        }}
-                        onDayPress={(day) => {
-                          const parts = parseDateParts(day.dateString);
-
-                          if (calendarTarget === "start") {
-                            setStartDateYear(parts.year);
-                            setStartDateMonth(parts.month);
-                            setStartDateDay(parts.day);
-                          } else {
-                            setEndDateYear(parts.year);
-                            setEndDateMonth(parts.month);
-                            setEndDateDay(parts.day);
-                          }
-
-                          setShowCalendar(false);
-                        }}
-                      />
-                    </View>
-                  )}
-                </View>
-
-                <View style={styles.inputBlock}>
-                  <View
-                    style={{
-                      flexDirection: "row",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                      marginBottom: 10,
-                    }}
-                  >
-                    <Text style={styles.editSectionLabel}>시간 설정</Text>
-                    <Switch
-                      value={isTimed}
-                      onValueChange={(value) => {
-                        setIsTimed(value);
-                        if (!value) setIsNotify(false);
-                      }}
-                      trackColor={{ true: "#9FA2D6" }}
-                    />
-                  </View>
-
-                  {isTimed && (
-                    <>
-                      <Text style={[styles.editSectionLabel, { marginTop: 8 }]}>
-                        시작 시간
-                      </Text>
-                      <View style={styles.timePickerRow}>
-                        <TimeStepperControl
-                          label="시"
-                          value={startHour}
-                          onIncrease={() =>
-                            setStartHour(getNextHour(startHour))
-                          }
-                          onDecrease={() =>
-                            setStartHour(getPrevHour(startHour))
-                          }
-                          onChange={setStartHour}
-                          onInputFocus={() => {
-                            setTimeout(() => {
-                              editScrollRef.current?.scrollTo({
-                                y: 360,
-                                animated: true,
-                              });
-                            }, 250);
-                          }}
-                        />
-                        <TimeStepperControl
-                          label="분"
-                          value={startMinute}
-                          onIncrease={() =>
-                            setStartMinute(getNextMinute(startMinute))
-                          }
-                          onDecrease={() =>
-                            setStartMinute(getPrevMinute(startMinute))
-                          }
-                        />
-                      </View>
-
-                      <Text
-                        style={[styles.editSectionLabel, { marginTop: 12 }]}
-                      >
-                        종료 시간
-                      </Text>
-                      <View style={styles.timePickerRow}>
-                        <TimeStepperControl
-                          label="시"
-                          value={endHour}
-                          onIncrease={() => setEndHour(getNextHour(endHour))}
-                          onDecrease={() => setEndHour(getPrevHour(endHour))}
-                          onChange={setEndHour}
-                          onInputFocus={() => {
-                            setTimeout(() => {
-                              editScrollRef.current?.scrollTo({
-                                y: 460,
-                                animated: true,
-                              });
-                            }, 250);
-                          }}
-                        />
-                        <TimeStepperControl
-                          label="분"
-                          value={endMinute}
-                          onIncrease={() =>
-                            setEndMinute(getNextMinute(endMinute))
-                          }
-                          onDecrease={() =>
-                            setEndMinute(getPrevMinute(endMinute))
-                          }
-                        />
-                      </View>
                     </>
                   )}
                 </View>
-                {isTimed && (
-                  <View style={styles.inputBlock}>
-                    <View style={styles.notifyRow}>
-                      <View style={styles.notifyLabelWrap}>
-                        <IconSymbol name="bell" size={18} color="#405886" />
-                        <Text style={styles.editSectionLabelInline}>알림</Text>
-                      </View>
+              </View>
+              {!isEditMode ? (
+                <>
+                  <View style={styles.titleRow}>
+                    <Text style={styles.detailRoutineTitle} numberOfLines={2}>
+                      {previewRoutine.title}
+                    </Text>
 
-                      <View style={styles.notifySwitchRow}>
-                        <Text style={styles.notifyStateText}>
-                          {isNotify ? "켜짐" : "꺼짐"}
+                    <View
+                      style={[
+                        styles.tagBadge,
+                        { backgroundColor: categoryStyle.bg },
+                      ]}
+                    >
+                      <Text style={[styles.tagText, { color: "#233255" }]}>
+                        {previewRoutine.categoryName ?? "카테고리 없음"}{" "}
+                      </Text>
+                    </View>
+                  </View>
+
+                  <View style={styles.infoList}>
+                    <View style={styles.detailInfoRow}>
+                      <IconSymbol name="calendar" size={18} color="#A0B0D0" />
+                      <View style={styles.infoTextGroup}>
+                        <Text style={styles.detailLabel}>날짜</Text>
+                        <Text style={styles.detailValue}>
+                          {formatDateRange(
+                            previewRoutine.startDate,
+                            previewRoutine.endDate,
+                          )}
                         </Text>
-                        <Switch
-                          value={isNotify}
-                          onValueChange={(value) => {
-                            setIsNotify(value);
-                          }}
-                          trackColor={{ false: "#D8DEE8", true: "#9FA2D6" }}
-                        />
+                      </View>
+                    </View>
+
+                    <View style={styles.detailInfoRow}>
+                      <IconSymbol name="clock" size={18} color="#A0B0D0" />
+                      <View style={styles.infoTextGroup}>
+                        <Text style={styles.detailLabel}>시간</Text>
+                        <Text style={styles.detailValue}>
+                          {formatTimeRange(
+                            previewRoutine.startTime,
+                            previewRoutine.endTime,
+                          )}
+                        </Text>
+                      </View>
+                    </View>
+
+                    <View style={styles.detailInfoRow}>
+                      <IconSymbol name="bell" size={18} color="#A0B0D0" />
+                      <View style={styles.infoTextGroup}>
+                        <Text style={styles.detailLabel}>알림</Text>
+                        <Text style={styles.detailValue}>
+                          {getNotifyText(previewRoutine)}
+                        </Text>
+                      </View>
+                    </View>
+
+                    <View style={styles.detailInfoRow}>
+                      <IconSymbol name="repeat" size={18} color="#A0B0D0" />
+                      <View style={styles.infoTextGroup}>
+                        <Text style={styles.detailLabel}>반복 설정</Text>
+                        <Text style={styles.detailValue}>
+                          {getRepeatText(previewRoutine)}
+                        </Text>
                       </View>
                     </View>
                   </View>
-                )}
-                <View style={styles.inputBlock}>
-                  <View
-                    style={{
-                      flexDirection: "row",
-                      justifyContent: "space-between",
-                      alignItems: "center",
-                      marginBottom: 8,
-                    }}
-                  >
-                    <Text
-                      style={[styles.editSectionLabel, { marginBottom: 0 }]}
-                    >
-                      반복 설정
-                    </Text>
+                </>
+              ) : (
+                <ScrollView
+                  ref={editScrollRef}
+                  style={styles.editScroll}
+                  contentContainerStyle={styles.editScrollContent}
+                  showsVerticalScrollIndicator={false}
+                  nestedScrollEnabled
+                  keyboardShouldPersistTaps="always"
+                  keyboardDismissMode="on-drag"
+                >
+                  <View style={styles.inputBlock}>
+                    <Text style={styles.editSectionLabel}>제목</Text>
+                    <TextInput
+                      value={title}
+                      onChangeText={setTitle}
+                      placeholder="루틴 제목을 입력해 주세요"
+                      placeholderTextColor="#B4B6C0"
+                      style={styles.titleInput}
+                    />
+                  </View>
 
-                    <TouchableOpacity
-                      style={styles.repeatCurrentChip}
-                      onPress={() => {
-                        setShowRepeatPanel((prev) => !prev);
-                        setShowCustomRepeatPanel(false);
+                  <View style={styles.inputBlock}>
+                    <Text style={styles.editSectionLabel}>카테고리</Text>
+                    <ScrollView
+                      horizontal
+                      showsHorizontalScrollIndicator={false}
+                      contentContainerStyle={{
+                        gap: 6,
+                        paddingVertical: 2,
+                        marginTop: 12,
                       }}
                     >
-                      <View style={styles.repeatCurrentChipContent}>
-                        <Text style={styles.repeatCurrentChipText}>
-                          {getRepeatLabel(
-                            repeatType,
-                            repeatInterval,
-                            repeatUnit,
-                            repeatDays,
-                          )}
-                        </Text>
-                        <Text style={styles.repeatCurrentChevron}>▾</Text>
-                      </View>
-                    </TouchableOpacity>
-                  </View>
-                  {/* 빠른 선택 패널 */}
-                  {showRepeatPanel && (
-                    <View style={{ marginTop: 8, gap: 6 }}>
-                      {[
-                        { label: "매일", value: "DAILY" as RepeatType },
-                        {
-                          label: `매주 (${
-                            WEEKDAY_OPTIONS.find(
-                              (d) =>
-                                d.value ===
-                                getWeekdayValueFromDate(
-                                  makeDate(
-                                    startDateYear,
-                                    startDateMonth,
-                                    startDateDay,
-                                  ),
-                                ),
-                            )?.label ?? ""
-                          })`,
-                          value: "QUICK_WEEKLY",
-                        },
-                        {
-                          label: `격주 (${
-                            WEEKDAY_OPTIONS.find(
-                              (d) =>
-                                d.value ===
-                                getWeekdayValueFromDate(
-                                  makeDate(
-                                    startDateYear,
-                                    startDateMonth,
-                                    startDateDay,
-                                  ),
-                                ),
-                            )?.label ?? ""
-                          })`,
-                          value: "QUICK_BIWEEKLY",
-                        },
-                        {
-                          label: "사용자 설정",
-                          value: "CUSTOM" as RepeatType,
-                        },
-                      ].map((item) => {
-                        const isSelected =
-                          (repeatType === "DAILY" && item.value === "DAILY") ||
-                          (repeatType === "WEEKDAYS" &&
-                            item.value === "WEEKDAYS") ||
-                          (repeatType === "CUSTOM" &&
-                            repeatUnit === "WEEK" &&
-                            repeatInterval === "1" &&
-                            item.value === "QUICK_WEEKLY") ||
-                          (repeatType === "CUSTOM" &&
-                            repeatUnit === "WEEK" &&
-                            repeatInterval === "2" &&
-                            item.value === "QUICK_BIWEEKLY") ||
-                          (repeatType === "CUSTOM" &&
-                            !(
-                              repeatUnit === "WEEK" &&
-                              (repeatInterval === "1" || repeatInterval === "2")
-                            ) &&
-                            item.value === "CUSTOM");
+                      {categoryList.map((cat) => {
+                        const chipStyle = getCategoryChipStyle(
+                          cat,
+                          customCategoryColorMap,
+                        );
+                        const isSelected = categoryName === cat;
 
                         return (
                           <TouchableOpacity
-                            key={item.value}
+                            key={cat}
                             style={[
-                              styles.repeatOptionButton,
-                              isSelected && styles.repeatOptionButtonSelected,
+                              styles.categoryChip,
+                              {
+                                backgroundColor: chipStyle.bg,
+                                borderColor: isSelected
+                                  ? chipStyle.dot
+                                  : "transparent",
+                                borderWidth: isSelected ? 1.5 : 1,
+                              },
                             ]}
                             onPress={() => {
-                              if (item.value === "QUICK_WEEKLY") {
-                                handleSelectQuickWeeklyRepeat("1");
-                              } else if (item.value === "QUICK_BIWEEKLY") {
-                                handleSelectQuickWeeklyRepeat("2");
-                              } else {
-                                handleSelectRepeatType(
-                                  item.value as RepeatType,
-                                );
-                              }
+                              setCategoryName(cat);
+                              setSelectedColor(chipStyle.dot);
                             }}
                           >
                             <Text
                               style={[
-                                styles.repeatOptionText,
-                                isSelected && styles.repeatOptionTextSelected,
+                                styles.categoryChipText,
+                                { color: "#233255" },
                               ]}
                             >
-                              {item.label}
+                              {cat}
                             </Text>
                           </TouchableOpacity>
                         );
                       })}
+                    </ScrollView>
+                  </View>
+
+                  <View style={styles.inputBlock}>
+                    <Text style={styles.editSectionLabel}>날짜</Text>
+                    <View style={styles.dateRangeBlock}>
+                      <TouchableOpacity
+                        style={styles.dateSelectButton}
+                        onPress={() => {
+                          setCalendarTarget("start");
+                          setShowCalendar((prev) =>
+                            calendarTarget === "start" ? !prev : true,
+                          );
+                        }}
+                      >
+                        <View style={styles.dateSelectLeft}>
+                          <IconSymbol
+                            name="calendar"
+                            size={18}
+                            color="#405886"
+                          />
+                          <Text style={styles.dateSelectText}>
+                            시작일 · {formatDate(selectedStartDateString)}
+                          </Text>
+                        </View>
+
+                        <IconSymbol
+                          name={
+                            showCalendar && calendarTarget === "start"
+                              ? "chevron.up"
+                              : "chevron.down"
+                          }
+                          size={16}
+                          color="#A0B0D0"
+                        />
+                      </TouchableOpacity>
+
+                      <TouchableOpacity
+                        style={[
+                          styles.dateSelectButton,
+                          !hasEndDate && { opacity: 0.5 },
+                        ]}
+                        onPress={() => {
+                          if (!hasEndDate) return;
+                          setCalendarTarget("end");
+                          setShowCalendar((prev) =>
+                            calendarTarget === "end" ? !prev : true,
+                          );
+                        }}
+                      >
+                        <View style={styles.dateSelectLeft}>
+                          <IconSymbol
+                            name="calendar"
+                            size={18}
+                            color="#405886"
+                          />
+                          <Text style={styles.dateSelectText}>
+                            종료일 ·{" "}
+                            {hasEndDate
+                              ? formatDate(selectedEndDateString)
+                              : "없음 (무한반복)"}
+                          </Text>
+                        </View>
+                        <TouchableOpacity
+                          onPress={() => {
+                            setHasEndDate((prev) => !prev);
+                            setShowCalendar(false);
+                          }}
+                          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                        >
+                          <Text
+                            style={{
+                              fontSize: 12,
+                              color: "#9FA2D6",
+                              fontWeight: "700",
+                            }}
+                          >
+                            {hasEndDate ? "종료일 해제" : "종료일 설정"}
+                          </Text>
+                        </TouchableOpacity>
+                      </TouchableOpacity>
+                    </View>
+
+                    {showCalendar && (
+                      <View style={styles.calendarContainer}>
+                        <AppCalendar
+                          current={selectedCalendarDateString}
+                          markedDates={{
+                            [selectedCalendarDateString]: {
+                              selected: true,
+                              selectedColor: "#F1F1FB",
+                            },
+                          }}
+                          onDayPress={(day) => {
+                            const parts = parseDateParts(day.dateString);
+
+                            if (calendarTarget === "start") {
+                              setStartDateYear(parts.year);
+                              setStartDateMonth(parts.month);
+                              setStartDateDay(parts.day);
+                            } else {
+                              setEndDateYear(parts.year);
+                              setEndDateMonth(parts.month);
+                              setEndDateDay(parts.day);
+                            }
+
+                            setShowCalendar(false);
+                          }}
+                        />
+                      </View>
+                    )}
+                  </View>
+
+                  <View style={styles.inputBlock}>
+                    <View
+                      style={{
+                        flexDirection: "row",
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                        marginBottom: 10,
+                      }}
+                    >
+                      <Text style={styles.editSectionLabel}>시간 설정</Text>
+                      <Switch
+                        value={isTimed}
+                        onValueChange={(value) => {
+                          setIsTimed(value);
+                          if (!value) setIsNotify(false);
+                        }}
+                        trackColor={{ true: "#9FA2D6" }}
+                      />
+                    </View>
+
+                    {isTimed && (
+                      <TouchableOpacity
+                        style={styles.dateSelectButton}
+                        onPress={() => setShowTimeModal(true)}
+                      >
+                        <View style={styles.dateSelectLeft}>
+                          <IconSymbol name="clock" size={18} color="#405886" />
+                          <Text style={styles.dateSelectText}>
+                            {`${startHour.padStart(2, "0")}:${startMinute.padStart(2, "0")} ~ ${endHour.padStart(2, "0")}:${endMinute.padStart(2, "0")}`}
+                          </Text>
+                        </View>
+                        <IconSymbol
+                          name="chevron.right"
+                          size={16}
+                          color="#A0B0D0"
+                        />
+                      </TouchableOpacity>
+                    )}
+                  </View>
+                  {isTimed && (
+                    <View style={styles.inputBlock}>
+                      <View style={styles.notifyRow}>
+                        <View style={styles.notifyLabelWrap}>
+                          <IconSymbol name="bell" size={18} color="#405886" />
+                          <Text style={styles.editSectionLabelInline}>
+                            알림
+                          </Text>
+                        </View>
+
+                        <View style={styles.notifySwitchRow}>
+                          <Text style={styles.notifyStateText}>
+                            {isNotify ? "켜짐" : "꺼짐"}
+                          </Text>
+                          <Switch
+                            value={isNotify}
+                            onValueChange={(value) => {
+                              setIsNotify(value);
+                            }}
+                            trackColor={{ false: "#D8DEE8", true: "#9FA2D6" }}
+                          />
+                        </View>
+                      </View>
                     </View>
                   )}
+                  <View style={styles.inputBlock}>
+                    <View
+                      style={{
+                        flexDirection: "row",
+                        justifyContent: "space-between",
+                        alignItems: "center",
+                        marginBottom: 8,
+                      }}
+                    >
+                      <Text
+                        style={[styles.editSectionLabel, { marginBottom: 0 }]}
+                      >
+                        반복 설정
+                      </Text>
 
-                  {/* 사용자 설정 패널 */}
-                  {showCustomRepeatPanel && (
-                    <View style={{ marginTop: 12, gap: 14 }}>
-                      {/* 단위 - 일/주 */}
-                      <View>
-                        <Text style={styles.dialLabel}>단위</Text>
-                        <View style={{ flexDirection: "row", gap: 8 }}>
-                          {(["DAY", "WEEK"] as RepeatUnit[]).map((unit) => (
+                      <TouchableOpacity
+                        style={styles.repeatCurrentChip}
+                        onPress={() => {
+                          setShowRepeatPanel((prev) => !prev);
+                          setShowCustomRepeatPanel(false);
+                        }}
+                      >
+                        <View style={styles.repeatCurrentChipContent}>
+                          <Text style={styles.repeatCurrentChipText}>
+                            {getRepeatLabel(
+                              repeatType,
+                              repeatInterval,
+                              repeatUnit,
+                              repeatDays,
+                            )}
+                          </Text>
+                          <Text style={styles.repeatCurrentChevron}>▾</Text>
+                        </View>
+                      </TouchableOpacity>
+                    </View>
+                    {/* 빠른 선택 패널 */}
+                    {showRepeatPanel && (
+                      <View style={{ marginTop: 8, gap: 6 }}>
+                        {[
+                          { label: "매일", value: "DAILY" as RepeatType },
+                          {
+                            label: `매주 (${
+                              WEEKDAY_OPTIONS.find(
+                                (d) =>
+                                  d.value ===
+                                  getWeekdayValueFromDate(
+                                    makeDate(
+                                      startDateYear,
+                                      startDateMonth,
+                                      startDateDay,
+                                    ),
+                                  ),
+                              )?.label ?? ""
+                            })`,
+                            value: "QUICK_WEEKLY",
+                          },
+                          {
+                            label: `격주 (${
+                              WEEKDAY_OPTIONS.find(
+                                (d) =>
+                                  d.value ===
+                                  getWeekdayValueFromDate(
+                                    makeDate(
+                                      startDateYear,
+                                      startDateMonth,
+                                      startDateDay,
+                                    ),
+                                  ),
+                              )?.label ?? ""
+                            })`,
+                            value: "QUICK_BIWEEKLY",
+                          },
+                          {
+                            label: "사용자 설정",
+                            value: "CUSTOM" as RepeatType,
+                          },
+                        ].map((item) => {
+                          const isSelected =
+                            (repeatType === "DAILY" &&
+                              item.value === "DAILY") ||
+                            (repeatType === "WEEKDAYS" &&
+                              item.value === "WEEKDAYS") ||
+                            (repeatType === "CUSTOM" &&
+                              repeatUnit === "WEEK" &&
+                              repeatInterval === "1" &&
+                              item.value === "QUICK_WEEKLY") ||
+                            (repeatType === "CUSTOM" &&
+                              repeatUnit === "WEEK" &&
+                              repeatInterval === "2" &&
+                              item.value === "QUICK_BIWEEKLY") ||
+                            (repeatType === "CUSTOM" &&
+                              !(
+                                repeatUnit === "WEEK" &&
+                                (repeatInterval === "1" ||
+                                  repeatInterval === "2")
+                              ) &&
+                              item.value === "CUSTOM");
+
+                          return (
                             <TouchableOpacity
-                              key={unit}
+                              key={item.value}
                               style={[
                                 styles.repeatOptionButton,
-                                repeatUnit === unit &&
-                                  styles.repeatOptionButtonSelected,
-                                { flex: 1, alignItems: "center" },
+                                isSelected && styles.repeatOptionButtonSelected,
                               ]}
-                              onPress={() => handleSelectCustomRepeatUnit(unit)}
+                              onPress={() => {
+                                if (item.value === "QUICK_WEEKLY") {
+                                  handleSelectQuickWeeklyRepeat("1");
+                                } else if (item.value === "QUICK_BIWEEKLY") {
+                                  handleSelectQuickWeeklyRepeat("2");
+                                } else {
+                                  handleSelectRepeatType(
+                                    item.value as RepeatType,
+                                  );
+                                }
+                              }}
                             >
                               <Text
                                 style={[
                                   styles.repeatOptionText,
-                                  repeatUnit === unit &&
-                                    styles.repeatOptionTextSelected,
+                                  isSelected && styles.repeatOptionTextSelected,
                                 ]}
                               >
-                                {unit === "DAY" ? "일" : "주"}
+                                {item.label}
                               </Text>
                             </TouchableOpacity>
-                          ))}
-                        </View>
+                          );
+                        })}
                       </View>
+                    )}
 
-                      {/* 빈도 */}
-                      <View>
-                        <Text style={styles.dialLabel}>빈도</Text>
-                        {repeatUnit === "WEEK" ? (
+                    {/* 사용자 설정 패널 */}
+                    {showCustomRepeatPanel && (
+                      <View style={{ marginTop: 12, gap: 14 }}>
+                        {/* 단위 - 일/주 */}
+                        <View>
+                          <Text style={styles.dialLabel}>단위</Text>
                           <View style={{ flexDirection: "row", gap: 8 }}>
-                            {WEEK_REPEAT_EVERY_OPTIONS.map((opt) => (
+                            {(["DAY", "WEEK"] as RepeatUnit[]).map((unit) => (
                               <TouchableOpacity
-                                key={opt}
+                                key={unit}
                                 style={[
                                   styles.repeatOptionButton,
-                                  repeatInterval === opt &&
+                                  repeatUnit === unit &&
                                     styles.repeatOptionButtonSelected,
                                   { flex: 1, alignItems: "center" },
                                 ]}
-                                onPress={() => setRepeatInterval(opt)}
+                                onPress={() =>
+                                  handleSelectCustomRepeatUnit(unit)
+                                }
                               >
                                 <Text
                                   style={[
                                     styles.repeatOptionText,
-                                    repeatInterval === opt &&
+                                    repeatUnit === unit &&
                                       styles.repeatOptionTextSelected,
                                   ]}
                                 >
-                                  {opt === "1" ? "매주" : "격주"}
+                                  {unit === "DAY" ? "일" : "주"}
                                 </Text>
                               </TouchableOpacity>
                             ))}
                           </View>
-                        ) : (
-                          <View style={styles.repeatIntervalStepper}>
-                            <TouchableOpacity
-                              style={styles.repeatStepperButton}
-                              onPress={() => {
-                                const next = Math.max(
-                                  1,
-                                  Number(repeatInterval || "1") - 1,
-                                );
-                                setRepeatInterval(String(next));
-                              }}
-                            >
-                              <Text style={styles.repeatStepperButtonText}>
-                                -
-                              </Text>
-                            </TouchableOpacity>
+                        </View>
 
-                            <View style={styles.repeatIntervalInputBox}>
-                              <TextInput
-                                style={styles.repeatIntervalInput}
-                                value={repeatInterval}
-                                onFocus={scrollToRepeatInput}
-                                onChangeText={(text) => {
-                                  const onlyNumber = text.replace(
-                                    /[^0-9]/g,
-                                    "",
-                                  );
-                                  if (onlyNumber === "") {
-                                    setRepeatInterval("");
-                                    return;
-                                  }
-                                  setRepeatInterval(
-                                    String(
-                                      Math.min(
-                                        999,
-                                        Math.max(1, Number(onlyNumber)),
-                                      ),
-                                    ),
-                                  );
-                                }}
-                                onBlur={() => {
-                                  if (
-                                    !repeatInterval ||
-                                    Number(repeatInterval) < 1
-                                  )
-                                    setRepeatInterval("1");
-                                }}
-                                keyboardType="number-pad"
-                                returnKeyType="done"
-                                maxLength={3}
-                              />
-                              <Text style={styles.repeatIntervalSuffix}>
-                                일마다
-                              </Text>
-                            </View>
-
-                            <TouchableOpacity
-                              style={styles.repeatStepperButton}
-                              onPress={() => {
-                                const next = Math.min(
-                                  999,
-                                  Number(repeatInterval || "1") + 1,
-                                );
-                                setRepeatInterval(String(next));
-                              }}
-                            >
-                              <Text style={styles.repeatStepperButtonText}>
-                                +
-                              </Text>
-                            </TouchableOpacity>
-                          </View>
-                        )}
-                      </View>
-
-                      {/* 요일 (주 단위일 때만) */}
-                      {repeatUnit === "WEEK" && (
+                        {/* 빈도 */}
                         <View>
-                          <Text style={styles.dialLabel}>요일</Text>
-                          <View style={styles.weekdayRow}>
-                            {WEEKDAY_OPTIONS.map((day) => {
-                              const isSelected = repeatDays.includes(day.value);
-                              return (
+                          <Text style={styles.dialLabel}>빈도</Text>
+                          {repeatUnit === "WEEK" ? (
+                            <View style={{ flexDirection: "row", gap: 8 }}>
+                              {WEEK_REPEAT_EVERY_OPTIONS.map((opt) => (
                                 <TouchableOpacity
-                                  key={day.value}
+                                  key={opt}
                                   style={[
-                                    styles.weekdayChip,
-                                    isSelected && styles.weekdayChipSelected,
+                                    styles.repeatOptionButton,
+                                    repeatInterval === opt &&
+                                      styles.repeatOptionButtonSelected,
+                                    { flex: 1, alignItems: "center" },
                                   ]}
-                                  onPress={() => handleToggleWeekday(day.value)}
+                                  onPress={() => setRepeatInterval(opt)}
                                 >
                                   <Text
                                     style={[
-                                      styles.weekdayChipText,
-                                      isSelected &&
-                                        styles.weekdayChipTextSelected,
+                                      styles.repeatOptionText,
+                                      repeatInterval === opt &&
+                                        styles.repeatOptionTextSelected,
                                     ]}
                                   >
-                                    {day.label}
+                                    {opt === "1" ? "매주" : "격주"}
                                   </Text>
                                 </TouchableOpacity>
-                              );
-                            })}
-                          </View>
-                        </View>
-                      )}
+                              ))}
+                            </View>
+                          ) : (
+                            <View style={styles.repeatIntervalStepper}>
+                              <TouchableOpacity
+                                style={styles.repeatStepperButton}
+                                onPress={() => {
+                                  const next = Math.max(
+                                    1,
+                                    Number(repeatInterval || "1") - 1,
+                                  );
+                                  setRepeatInterval(String(next));
+                                }}
+                              >
+                                <Text style={styles.repeatStepperButtonText}>
+                                  -
+                                </Text>
+                              </TouchableOpacity>
 
-                      <TouchableOpacity
-                        style={[
-                          styles.repeatOptionButton,
-                          styles.repeatOptionButtonSelected,
-                        ]}
-                        onPress={handleSaveCustomRepeat}
-                      >
-                        <Text
+                              <View style={styles.repeatIntervalInputBox}>
+                                <TextInput
+                                  style={styles.repeatIntervalInput}
+                                  value={repeatInterval}
+                                  onFocus={scrollToRepeatInput}
+                                  onChangeText={(text) => {
+                                    const onlyNumber = text.replace(
+                                      /[^0-9]/g,
+                                      "",
+                                    );
+                                    if (onlyNumber === "") {
+                                      setRepeatInterval("");
+                                      return;
+                                    }
+                                    setRepeatInterval(
+                                      String(
+                                        Math.min(
+                                          999,
+                                          Math.max(1, Number(onlyNumber)),
+                                        ),
+                                      ),
+                                    );
+                                  }}
+                                  onBlur={() => {
+                                    if (
+                                      !repeatInterval ||
+                                      Number(repeatInterval) < 1
+                                    )
+                                      setRepeatInterval("1");
+                                  }}
+                                  keyboardType="number-pad"
+                                  returnKeyType="done"
+                                  maxLength={3}
+                                />
+                                <Text style={styles.repeatIntervalSuffix}>
+                                  일마다
+                                </Text>
+                              </View>
+
+                              <TouchableOpacity
+                                style={styles.repeatStepperButton}
+                                onPress={() => {
+                                  const next = Math.min(
+                                    999,
+                                    Number(repeatInterval || "1") + 1,
+                                  );
+                                  setRepeatInterval(String(next));
+                                }}
+                              >
+                                <Text style={styles.repeatStepperButtonText}>
+                                  +
+                                </Text>
+                              </TouchableOpacity>
+                            </View>
+                          )}
+                        </View>
+
+                        {/* 요일 (주 단위일 때만) */}
+                        {repeatUnit === "WEEK" && (
+                          <View>
+                            <Text style={styles.dialLabel}>요일</Text>
+                            <View style={styles.weekdayRow}>
+                              {WEEKDAY_OPTIONS.map((day) => {
+                                const isSelected = repeatDays.includes(
+                                  day.value,
+                                );
+                                return (
+                                  <TouchableOpacity
+                                    key={day.value}
+                                    style={[
+                                      styles.weekdayChip,
+                                      isSelected && styles.weekdayChipSelected,
+                                    ]}
+                                    onPress={() =>
+                                      handleToggleWeekday(day.value)
+                                    }
+                                  >
+                                    <Text
+                                      style={[
+                                        styles.weekdayChipText,
+                                        isSelected &&
+                                          styles.weekdayChipTextSelected,
+                                      ]}
+                                    >
+                                      {day.label}
+                                    </Text>
+                                  </TouchableOpacity>
+                                );
+                              })}
+                            </View>
+                          </View>
+                        )}
+
+                        <TouchableOpacity
                           style={[
-                            styles.repeatOptionText,
-                            styles.repeatOptionTextSelected,
-                            { textAlign: "center" },
+                            styles.repeatOptionButton,
+                            styles.repeatOptionButtonSelected,
                           ]}
+                          onPress={handleSaveCustomRepeat}
                         >
-                          완료
-                        </Text>
-                      </TouchableOpacity>
-                    </View>
-                  )}
-                </View>
-              </ScrollView>
-            )}
-          </View>
-        </Animated.View>
-      </View>
-    </Modal>
+                          <Text
+                            style={[
+                              styles.repeatOptionText,
+                              styles.repeatOptionTextSelected,
+                              { textAlign: "center" },
+                            ]}
+                          >
+                            완료
+                          </Text>
+                        </TouchableOpacity>
+                      </View>
+                    )}
+                  </View>
+                </ScrollView>
+              )}
+            </View>
+          </Animated.View>
+        </View>
+        <TimePickerModal
+          visible={showTimeModal}
+          startHour={startHour}
+          startMinute={startMinute}
+          endHour={endHour}
+          endMinute={endMinute}
+          onClose={() => setShowTimeModal(false)}
+          onApply={handleApplyTime}
+        />
+      </Modal>
+    </>
   );
 }
 
@@ -1793,62 +1676,6 @@ const styles = StyleSheet.create({
     paddingBottom: 10,
   },
 
-  timePickerRow: {
-    flexDirection: "row",
-    gap: 8,
-  },
-  timeStepperRow: {
-    flexDirection: "row",
-    alignItems: "center",
-    justifyContent: "space-between",
-    gap: 6,
-  },
-  timeStepperBox: {
-    flex: 1,
-    borderRadius: 14,
-    paddingVertical: 6,
-    paddingHorizontal: 6,
-    alignItems: "center",
-  },
-  timeStepperLabel: {
-    fontSize: 12,
-    fontWeight: "700",
-    color: "#A0B0D0",
-    marginBottom: 8,
-  },
-  timeStepperButton: {
-    width: 30,
-    height: 34,
-    borderRadius: 8,
-    backgroundColor: "#F1F4F9",
-    alignItems: "center",
-    justifyContent: "center",
-  },
-  timeStepperButtonText: {
-    fontSize: 18,
-    fontWeight: "800",
-    color: "#405886",
-    textAlign: "center",
-    includeFontPadding: false,
-    lineHeight: 18,
-  },
-  timeStepperValueBox: {
-    flex: 2,
-    height: 40,
-    borderRadius: 12,
-    alignItems: "center",
-    justifyContent: "center",
-    marginVertical: 6,
-  },
-  timeStepperValueText: {
-    fontSize: 18,
-    fontWeight: "800",
-    color: "#2A3C6B",
-    textAlign: "center",
-    includeFontPadding: false,
-    lineHeight: 20,
-  },
-
   notifyRow: {
     flexDirection: "row",
     justifyContent: "space-between",
@@ -1950,18 +1777,6 @@ const styles = StyleSheet.create({
     backgroundColor: "#F3F4F8",
     borderWidth: 1,
     borderColor: "#E7EAF0",
-  },
-  timeStepperValueInput: {
-    flex: 2,
-    height: 40,
-    borderRadius: 12,
-    marginVertical: 6,
-    fontSize: 18,
-    fontWeight: "800",
-    color: "#2A3C6B",
-    textAlign: "center",
-    includeFontPadding: false,
-    lineHeight: 20,
   },
 
   repeatCurrentChip: {

--- a/components/time_picker_modal.tsx
+++ b/components/time_picker_modal.tsx
@@ -6,6 +6,7 @@ import {
   Modal,
   Platform,
   Pressable,
+  ScrollView,
   StyleSheet,
   TextInput,
   TouchableOpacity,
@@ -120,16 +121,19 @@ function HourStepperPicker({
     const cleaned = text.replace(/[^0-9]/g, "").slice(0, 2);
     setInputValue(cleaned);
 
-    if (Platform.OS === "android" && cleaned.length === 2) {
+    // 숫자가 입력될 때마다 바로 반영
+    if (cleaned.length > 0) {
       const num = parseInt(cleaned, 10);
-      const clamped = Math.min(23, Math.max(0, num));
-      const padded = padTwo(clamped);
-      setInputValue(padded);
-      onChange(padded);
+      if (!isNaN(num)) {
+        const clamped = Math.min(23, Math.max(0, num));
+        onChange(padTwo(clamped));
+      }
+    }
+
+    if (Platform.OS === "android" && cleaned.length === 2) {
       Keyboard.dismiss();
     }
   };
-
   const handleBlur = () => {
     setIsFocused(false);
     const num = parseInt(inputValue, 10);
@@ -185,7 +189,26 @@ const TimePickerModal = ({
   const [tempStartMinute, setTempStartMinute] = useState(startMinute);
   const [tempEndHour, setTempEndHour] = useState(endHour);
   const [tempEndMinute, setTempEndMinute] = useState(endMinute);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+  useEffect(() => {
+    const showEvent =
+      Platform.OS === "ios" ? "keyboardWillShow" : "keyboardDidShow";
+    const hideEvent =
+      Platform.OS === "ios" ? "keyboardWillHide" : "keyboardDidHide";
 
+    const showSub = Keyboard.addListener(showEvent, (e) => {
+      setKeyboardHeight(e.endCoordinates.height);
+    });
+
+    const hideSub = Keyboard.addListener(hideEvent, () => {
+      setKeyboardHeight(0);
+    });
+
+    return () => {
+      showSub.remove();
+      hideSub.remove();
+    };
+  }, []);
   useEffect(() => {
     if (visible) {
       setTempStartHour(startHour);
@@ -216,75 +239,89 @@ const TimePickerModal = ({
           style={styles.modalCard}
           onPress={(e) => e.stopPropagation()}
         >
-          <View style={styles.header}>
-            <ThemedText style={styles.title}>시간 설정</ThemedText>
+          <ScrollView
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator={false}
+            bounces={false}
+            contentContainerStyle={[
+              styles.scrollContent,
+              { paddingBottom: keyboardHeight > 0 ? keyboardHeight + 24 : 24 },
+            ]}
+          >
+            <View style={styles.header}>
+              <ThemedText style={styles.title}>시간 설정</ThemedText>
 
-            <TouchableOpacity onPress={onClose}>
-              <ThemedText style={styles.closeText}>닫기</ThemedText>
+              <TouchableOpacity onPress={onClose}>
+                <ThemedText style={styles.closeText}>닫기</ThemedText>
+              </TouchableOpacity>
+            </View>
+
+            <View style={styles.previewBox}>
+              <ThemedText style={styles.previewLabel}>선택된 시간</ThemedText>
+              <ThemedText style={styles.previewValue}>
+                {formatRangeLabel(
+                  tempStartHour,
+                  tempStartMinute,
+                  tempEndHour,
+                  tempEndMinute,
+                )}
+              </ThemedText>
+            </View>
+
+            <View style={styles.section}>
+              <ThemedText style={styles.sectionTitle}>시작 시간</ThemedText>
+              <View style={styles.pickerRow}>
+                <HourStepperPicker
+                  label="시"
+                  value={tempStartHour}
+                  onIncrease={() =>
+                    setTempStartHour(getNextHour(tempStartHour))
+                  }
+                  onDecrease={() =>
+                    setTempStartHour(getPrevHour(tempStartHour))
+                  }
+                  onChange={setTempStartHour}
+                />
+                <StepperPicker
+                  label="분"
+                  value={tempStartMinute}
+                  onIncrease={() =>
+                    setTempStartMinute(getNextMinute(tempStartMinute))
+                  }
+                  onDecrease={() =>
+                    setTempStartMinute(getPrevMinute(tempStartMinute))
+                  }
+                />
+              </View>
+            </View>
+
+            <View style={styles.section}>
+              <ThemedText style={styles.sectionTitle}>종료 시간</ThemedText>
+              <View style={styles.pickerRow}>
+                <HourStepperPicker
+                  label="시"
+                  value={tempEndHour}
+                  onIncrease={() => setTempEndHour(getNextHour(tempEndHour))}
+                  onDecrease={() => setTempEndHour(getPrevHour(tempEndHour))}
+                  onChange={setTempEndHour}
+                />
+                <StepperPicker
+                  label="분"
+                  value={tempEndMinute}
+                  onIncrease={() =>
+                    setTempEndMinute(getNextMinute(tempEndMinute))
+                  }
+                  onDecrease={() =>
+                    setTempEndMinute(getPrevMinute(tempEndMinute))
+                  }
+                />
+              </View>
+            </View>
+
+            <TouchableOpacity style={styles.applyButton} onPress={handleApply}>
+              <ThemedText style={styles.applyButtonText}>적용</ThemedText>
             </TouchableOpacity>
-          </View>
-
-          <View style={styles.previewBox}>
-            <ThemedText style={styles.previewLabel}>선택된 시간</ThemedText>
-            <ThemedText style={styles.previewValue}>
-              {formatRangeLabel(
-                tempStartHour,
-                tempStartMinute,
-                tempEndHour,
-                tempEndMinute,
-              )}
-            </ThemedText>
-          </View>
-
-          <View style={styles.section}>
-            <ThemedText style={styles.sectionTitle}>시작 시간</ThemedText>
-            <View style={styles.pickerRow}>
-              <HourStepperPicker
-                label="시"
-                value={tempStartHour}
-                onIncrease={() => setTempStartHour(getNextHour(tempStartHour))}
-                onDecrease={() => setTempStartHour(getPrevHour(tempStartHour))}
-                onChange={setTempStartHour}
-              />
-              <StepperPicker
-                label="분"
-                value={tempStartMinute}
-                onIncrease={() =>
-                  setTempStartMinute(getNextMinute(tempStartMinute))
-                }
-                onDecrease={() =>
-                  setTempStartMinute(getPrevMinute(tempStartMinute))
-                }
-              />
-            </View>
-          </View>
-
-          <View style={styles.section}>
-            <ThemedText style={styles.sectionTitle}>종료 시간</ThemedText>
-            <View style={styles.pickerRow}>
-              <HourStepperPicker
-                label="시"
-                value={tempEndHour}
-                onIncrease={() => setTempEndHour(getNextHour(tempEndHour))}
-                onDecrease={() => setTempEndHour(getPrevHour(tempEndHour))}
-                onChange={setTempEndHour}
-              />
-              <StepperPicker
-                label="분"
-                value={tempEndMinute}
-                onIncrease={() =>
-                  setTempEndMinute(getNextMinute(tempEndMinute))
-                }
-                onDecrease={() =>
-                  setTempEndMinute(getPrevMinute(tempEndMinute))
-                }
-              />
-            </View>
-          </View>
-
-          <TouchableOpacity style={styles.applyButton} onPress={handleApply}>
-            <ThemedText style={styles.applyButtonText}>적용</ThemedText>
-          </TouchableOpacity>
+          </ScrollView>
         </Pressable>
       </Pressable>
     </Modal>
@@ -304,12 +341,13 @@ const styles = StyleSheet.create({
 
   modalCard: {
     width: "100%",
-    maxWidth: 340,
     backgroundColor: "#FFFFFF",
     borderRadius: 22,
     paddingHorizontal: 16,
     paddingTop: 16,
     paddingBottom: 16,
+    maxWidth: 340,
+    maxHeight: "80%",
   },
 
   header: {
@@ -450,5 +488,9 @@ const styles = StyleSheet.create({
     fontWeight: "800",
     color: "#2A3C6B",
     textAlign: "center",
+  },
+
+  scrollContent: {
+    flexGrow: 1,
   },
 });

--- a/components/ui/_header.tsx
+++ b/components/ui/_header.tsx
@@ -52,12 +52,12 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     justifyContent: "space-between",
     alignItems: "center",
-    marginBottom: 20,
+    marginBottom: 12,
     paddingHorizontal: 8,
   },
   logoImage: {
-    width: 120,
-    height: 50,
+    width: 110,
+    height: 40,
     maxWidth: "50%",
   },
   logoText: {
@@ -70,9 +70,9 @@ const styles = StyleSheet.create({
   dot: { width: 8, height: 8, borderRadius: 4 },
 
   settingButton: {
-    width: 40,
-    height: 40,
-    borderRadius: 20,
+    width: 35,
+    height: 35,
+    borderRadius: 17,
     justifyContent: "center",
     alignItems: "center",
     marginLeft: 6,


### PR DESCRIPTION
## 관련 이슈

- Closes #86 
- Close #85 
---

## 작업 내용

- 카테고리 색상 선택 기능을 개선하여 인라인 컬러 피커 하단에 HEX 색상 코드를 직접 입력할 수 있는 입력 필드를 추가
- 루틴 및 카테고리 카드의 텍스트 색상을 색상 연산 없이 고정, 남색(#233255)으로 통일

- 카테고리에 연결된 루틴을 선택하면 루틴 목록 화면과 동일하게 상세 모달 및 수정 모달이 표시되도록 수정
- 카테고리명 레이아웃 수정

- 헤더 높이를 조정
- 날짜를 선택한 이후에도 달력 피커가 유지되도록 수정하여 연속적인 날짜 조회가 가능하도록 개선

- 시간 선택 시 변경된 시간이 즉시 화면에 반영되도록 수정
- 수정 모달에서도 추가 모달과 동일한 타임 피커 모달을 사용하도록 통일, 키보드가 표시될 때 모달 위치는 고정한 상태로 내부 콘텐츠만 스크롤되도록 변경


---

## 테스트 체크리스트

- [x] 예시

---

## 참고사항

-
